### PR TITLE
fix: removed Maven cache tasks from DB migration

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -175,14 +175,14 @@ stages:
             persistCredentials: true
             submodules: true
 
-          - task: Cache@2
-            inputs:
-              key: 'maven | "$(Agent.OS)" | pom.xml'
-              restoreKeys: |
-                maven | "$(Agent.OS)"
-                maven
-              path: $(MAVEN_CACHE_FOLDER)
-            displayName: Set Maven Cache
+#          - task: Cache@2
+#            inputs:
+#              key: 'maven | "$(Agent.OS)" | pom.xml'
+#              restoreKeys: |
+#                maven | "$(Agent.OS)"
+#                maven
+#              path: $(MAVEN_CACHE_FOLDER)
+#            displayName: Set Maven Cache
 
           - task: Bash@3
             name: dbmigrationsflywayMigrate
@@ -245,14 +245,14 @@ stages:
             persistCredentials: true
             submodules: true
 
-          - task: Cache@2
-            inputs:
-              key: 'maven | "$(Agent.OS)" | pom.xml'
-              restoreKeys: |
-                maven | "$(Agent.OS)"
-                maven
-              path: $(MAVEN_CACHE_FOLDER)
-            displayName: Set Maven Cache
+#          - task: Cache@2
+#            inputs:
+#              key: 'maven | "$(Agent.OS)" | pom.xml'
+#              restoreKeys: |
+#                maven | "$(Agent.OS)"
+#                maven
+#              path: $(MAVEN_CACHE_FOLDER)
+#            displayName: Set Maven Cache
 
           - task: Bash@3
             name: dbmigrationsflywayMigrate


### PR DESCRIPTION
With this commit the Maven cache task used in DB migration stage will be removed in order to execute correctly the pipeline.

#### List of Changes
 - Commented Maven cache task in deploy pipeline

#### Motivation and Context
As described up.

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.