### PR TITLE
[PAGOPA-735] Add new filter on read-all-reports' API

### DIFF
--- a/report/pom.xml
+++ b/report/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>
             <artifactId>reporting-analysis</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
         </dependency>
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>
             <artifactId>reporting-analysis</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.6-1</version>
         </dependency>
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>

--- a/reporting-analysis/openapi/openapi.json
+++ b/reporting-analysis/openapi/openapi.json
@@ -25,6 +25,17 @@
             },
             "required": true,
             "example": "90000000000"
+          },
+          {
+            "name": "flowDate",
+            "in": "query",
+            "description": "Filter by flow date (use the format yyyy-MM-dd)",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "required": false,
+            "example": "2020-01-01"
           }
         ],
         "responses": {

--- a/reporting-analysis/pom.xml
+++ b/reporting-analysis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.reporting</groupId>
     <artifactId>reporting-analysis</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <packaging>jar</packaging>
 
     <name>Azure Reporting-Analysis Fn</name>

--- a/reporting-analysis/pom.xml
+++ b/reporting-analysis/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.reporting</groupId>
     <artifactId>reporting-analysis</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.6-1</version>
     <packaging>jar</packaging>
 
     <name>Azure Reporting-Analysis Fn</name>

--- a/reporting-analysis/src/main/java/it/gov/pagopa/reporting/GetFlowList.java
+++ b/reporting-analysis/src/main/java/it/gov/pagopa/reporting/GetFlowList.java
@@ -47,7 +47,8 @@ public class GetFlowList {
         FlowsService flowsService = getFlowsServiceInstance(logger);
 
         try {
-            List<Flow> flows = flowsService.getByOrganization(organizationId);
+            String flowDate = request.getQueryParameters().getOrDefault("flowDate", null);
+            List<Flow> flows = flowsService.getByOrganization(organizationId, flowDate);
             ObjectMapper objectMapper = new ObjectMapper();
             final String data = objectMapper.writeValueAsString(flows);
 

--- a/reporting-analysis/src/test/java/it/gov/pagopa/reporting/GetFlowListTest.java
+++ b/reporting-analysis/src/test/java/it/gov/pagopa/reporting/GetFlowListTest.java
@@ -46,7 +46,7 @@ class GetFlowListTest {
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(flowsService).when(function).getFlowsServiceInstance(logger);
-        doReturn(flowList).when(flowsService).getByOrganization(organizationId);
+        doReturn(flowList).when(flowsService).getByOrganization(organizationId, "2022-01-01");
 
         final HttpResponseMessage.Builder builder = mock(HttpResponseMessage.Builder.class);
         HttpRequestMessage<Optional<String>> request = mock(HttpRequestMessage.class);
@@ -76,7 +76,7 @@ class GetFlowListTest {
         // precondition
         when(context.getLogger()).thenReturn(logger);
         doReturn(flowsService).when(function).getFlowsServiceInstance(logger);
-        doThrow(InvalidKeyException.class).when(flowsService).getByOrganization(organizationId);
+        doThrow(InvalidKeyException.class).when(flowsService).getByOrganization(organizationId, "2022-01-01");
 
         final HttpResponseMessage.Builder builder = mock(HttpResponseMessage.Builder.class);
         HttpRequestMessage<Optional<String>> request = mock(HttpRequestMessage.class);

--- a/reporting-analysis/src/test/java/it/gov/pagopa/reporting/service/FlowServiceIntegrationTest.java
+++ b/reporting-analysis/src/test/java/it/gov/pagopa/reporting/service/FlowServiceIntegrationTest.java
@@ -56,7 +56,7 @@ class FlowServiceIntegrationTest {
         List<Flow> flows = null;
         try {
             createTable();
-            flows = flowsService.getByOrganization(organizationId);
+            flows = flowsService.getByOrganization(organizationId, null);
         } catch (Exception e) {
             assertNull(flows);
         }


### PR DESCRIPTION
With this pull request, a new search filter, named `flowDate` is added on `organizations/{organizationId}/reportings` API. This filter permits to search one or more FdR reports based on their flow date.
This change is retrocompatible because the query parameter related to this search field is optional, thus can be omitted and the logic will be the same as before.

#### List of Changes
 - Added new filter for searching for flow date
 - Updated JUnit test

#### Motivation and Context
This change is required in order to search by reports' flow date

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.