### PR TITLE
[PAGOPA-942] feat: notification fee on debt positions

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,52 @@
+name: Integration Tests
+
+on:
+  schedule:
+    - cron: '00 08 * * *'
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        description: Select the Environment
+        options:
+          - dev
+          - uat
+      canary:
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+
+jobs:
+  integration_test:
+    name: Test
+    runs-on: ubuntu-latest
+    environment: ${{(github.event.inputs == null && 'dev') || inputs.environment }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@1f9a0c22da41e6ebfa534300ef656657ea2c6707
+
+      - name: Login
+        id: login
+        # from https://github.com/Azure/login/commits/master
+        uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
+
+      - name: Run Integration Tests
+        shell: bash
+        run: |
+          export CANARY=${{ inputs.canary }}
+          
+          cd ./gpd/integration-test
+          chmod +x ./run_integration_test.sh
+          ./run_integration_test.sh ${{( github.event.inputs == null && 'dev') || inputs.environment }} ${{ secrets.API_SUBSCRIPTION_KEY }}

--- a/gpd/integration-test/src/config/.env.local
+++ b/gpd/integration-test/src/config/.env.local
@@ -1,1 +1,1 @@
-gpd_host=http://localhost:8085
+gpd_host=http://localhost:8080

--- a/gpd/integration-test/src/features/debt-position-manage.feature
+++ b/gpd/integration-test/src/features/debt-position-manage.feature
@@ -8,6 +8,11 @@ Feature: Managing a debt position
     When the debt position is created
     Then the debt position gets the status code 201
 
+  Scenario: Debt position notification fee update
+    When the notification fee of the debt position is updated
+    Then the organization gets the status code 200
+    And the organization gets the updated amounts
+
   Scenario: Debt position filter list by status and due date
     Given the filter made by status "DRAFT"
     And the filter made by due date from today to 10 days

--- a/gpd/integration-test/src/step_definitions/support/clients/gpd_client.js
+++ b/gpd/integration-test/src/step_definitions/support/clients/gpd_client.js
@@ -102,6 +102,16 @@ function reportTransfer(orgId, iuv, idTransfer) {
     })
 }
 
+function updateNotificationFee(orgId, iuv, body) {
+    return put(gpd_host + `/organizations/${orgId}/paymentoptions/${iuv}/notificationfee`, body, {
+        timeout: 10000,
+        headers: {
+            "Ocp-Apim-Subscription-Key": process.env.API_SUBSCRIPTION_KEY,
+            "Content-Type": "application/json"
+        }
+    })
+}
+
 function createAndPublishDebtPosition(orgId, body) {
     return post(gpd_host + `/organizations/${orgId}/debtpositions`, body, {
         timeout: 10000,
@@ -120,6 +130,7 @@ module.exports = {
     createDebtPosition,
     publishDebtPosition,
     updateDebtPosition,
+    updateNotificationFee,
     getDebtPositionList,
     getDebtPosition,
     deleteDebtPosition,

--- a/gpd/integration-test/src/step_definitions/support/logic/common_logic.js
+++ b/gpd/integration-test/src/step_definitions/support/logic/common_logic.js
@@ -26,6 +26,13 @@ async function assertStatusString(bundle, statusString) {
     assert.strictEqual(bundle.responseToCheck.data.status, statusString);
 }
 
+async function assertNotificationFeeUpdatedAmounts(createdDebtPosition, response) {
+    let notificationFee = response.notificationFee;
+    assert.strictEqual(response.amount, createdDebtPosition.paymentOption[0].amount + notificationFee);
+    assert.strictEqual(response.transfer[0].amount, createdDebtPosition.paymentOption[0].transfer[0].amount + notificationFee);
+    assert.strictEqual(response.transfer[1].amount, createdDebtPosition.paymentOption[0].transfer[1].amount);
+}
+
 function randomOrg() {
     return "Org_" + Math.floor(Math.random() * 100);
 }
@@ -40,6 +47,7 @@ module.exports = {
     assertOutcome,
     assertStatusCode,
     assertCompanyName,
+    assertNotificationFeeUpdatedAmounts,
     assertStatusString,
     randomOrg,
     randomIupd,

--- a/gpd/integration-test/src/step_definitions/support/logic/gpd_logic.js
+++ b/gpd/integration-test/src/step_definitions/support/logic/gpd_logic.js
@@ -1,6 +1,7 @@
 const {
     createDebtPosition,
     updateDebtPosition,
+    updateNotificationFee,
     publishDebtPosition,
     deleteDebtPosition,
     getDebtPositionList,
@@ -20,12 +21,19 @@ async function executeDebtPositionCreation(bundle, idOrg, iupd) {
     bundle.debtPosition = buildDebtPositionDynamicData(bundle, iupd);
     let response = await createDebtPosition(bundle.organizationCode, buildCreateDebtPositionRequest(bundle.debtPosition, bundle.payer));
     bundle.responseToCheck = response;
+    bundle.createdDebtPosition = bundle.responseToCheck.data;
 }
 
 async function executeDebtPositionUpdate(bundle, idOrg, iupd) {
     bundle.iupd = iupd;
     let response = await updateDebtPosition(idOrg, iupd, bundle);
     bundle.responseToCheck = response;
+}
+
+async function executeDebtPositionNotificationFeeUpdate(bundle, idOrg, fee) {
+    let iuv = bundle.debtPosition.iuv1;
+    let response = await updateNotificationFee(idOrg, iuv, {notificationFee: fee});
+    bundle.responseToCheck = response;    
 }
 
 async function executeDebtPositionGetList(bundle, idOrg, dueDateFrom, dueDateTo, paymentDateFrom, paymentDateTo, status) {
@@ -72,6 +80,7 @@ module.exports = {
     executeDebtPositionDeletion,
     executeDebtPositionGetList,
     executeDebtPositionUpdate,
+    executeDebtPositionNotificationFeeUpdate,
     executeDebtPositionGet,
     executeDebtPositionPublish,
     executePaymentOptionPay,

--- a/gpd/integration-test/src/step_definitions/support/steps.js
+++ b/gpd/integration-test/src/step_definitions/support/steps.js
@@ -3,6 +3,7 @@ const { executeHealthCheckForGPD } = require('./logic/health_checks_logic');
 const { executeDebtPositionCreation,
         executeDebtPositionDeletion,
         executeDebtPositionGetList,
+        executeDebtPositionNotificationFeeUpdate,
         executeDebtPositionUpdate,
         executeDebtPositionGet,
         executeDebtPositionPublish,
@@ -10,7 +11,7 @@ const { executeDebtPositionCreation,
         executeReportTransfer,
         executeDebtPositionCreationAndPublication,
 } = require('./logic/gpd_logic');
-const { assertAmount, assertFaultCode, assertOutcome, assertStatusCode, assertCompanyName, assertStatusString, executeAfterAllStep, randomOrg, randomIupd } = require('./logic/common_logic');
+const { assertAmount, assertFaultCode, assertOutcome, assertStatusCode, assertCompanyName, assertNotificationFeeUpdatedAmounts, assertStatusString, executeAfterAllStep, randomOrg, randomIupd } = require('./logic/common_logic');
 const { gpdSessionBundle, gpdUpdateBundle, gpdPayBundle } = require('./utility/data');
 const { getValidBundle, addDays, format } = require('./utility/helpers');
 
@@ -59,10 +60,17 @@ When('we ask the list of organizations debt positions', async () => {
 Then('we get the status code {int}', (statusCode) => assertStatusCode(gpdSessionBundle, statusCode));
 
 /*
+ *  Debt position notification fee update
+ */
+When('the notification fee of the debt position is updated', () => executeDebtPositionNotificationFeeUpdate(gpdSessionBundle, idOrg, 150));
+Then('the organization gets the status code {int}', (statusCode) => assertStatusCode(gpdSessionBundle, statusCode));
+Then('the organization gets the updated amounts', () => assertNotificationFeeUpdatedAmounts(gpdSessionBundle.createdDebtPosition, gpdSessionBundle.responseToCheck.data));
+
+/*
  *  Debt position update
  */
 When('the debt position is updated', () => executeDebtPositionUpdate(gpdUpdateBundle, idOrg, iupd));
-Then('the organization gets the status code {int}', (statusCode) => assertStatusCode(gpdUpdateBundle, statusCode));
+
 
 /*
  *  Debt position get

--- a/gpd/integration-test/src/step_definitions/support/utility/request_builders.js
+++ b/gpd/integration-test/src/step_definitions/support/utility/request_builders.js
@@ -62,7 +62,7 @@ function buildCreateDebtPositionRequest(debtPosition, payer) {
                     },
                     {
                         idTransfer: debtPosition.transferId2,
-                        organizationFiscalCode: transferOtherCIFiscalCode,
+                        organizationFiscalCode: debtPosition.transferOtherCIFiscalCode,
                         amount: (debtPosition.amount * 100 / 3) * 2,
                         remittanceInformation: "Rata 2",
                         category: "9/0101108TS/",

--- a/gpd/load-test/src/create_debt_position.js
+++ b/gpd/load-test/src/create_debt_position.js
@@ -64,6 +64,7 @@ export default function () {
           "transfer": [
             {
               "idTransfer": "1",
+              "organizationFiscalCode": "00011122201"
               "amount": 8000,
               "remittanceInformation": "remittanceInformation 1",
               "category": "9/0101108TS/",

--- a/gpd/load-test/src/payments_workflow.js
+++ b/gpd/load-test/src/payments_workflow.js
@@ -31,7 +31,6 @@ export default function () {
   const transfer_id = '1';
 
   // Create new debt position (no validity date).
-
   var url = `${rootUrl}/organizations/${creditor_institution_code}/debtpositions`;
 
   var payload = JSON.stringify(
@@ -77,89 +76,91 @@ export default function () {
   var r = http.post(url, payload, params);
 
   //console.log("CreateDebtPosition call - creditor_institution_code = " + creditor_institution_code + ", Status = " + r.status);
-
   check(r, {
     'CreateDebtPosition status is 201': (r) => r.status === 201,
   });
 
+
+  // ----- NEXT STEP -----
+  // if the debt position has been correctly created => update notification fee
+  if (r.status !== 201) return; // exit flow if failed
+  url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}/notificationfee`;
+  payload = JSON.stringify({
+    "notificationFee": 150
+  });
+  r = http.put(url, payload, params);
+
+  //console.log("UpdateNotificationFee call - creditor_institution_code = " + creditor_institution_code + ", iupd = " + iupd + ", Status = " + r.status);
+  check(r, {
+    'UpdateNotificationFee status is 200': (r) => r.status === 200,
+  });
+
+
+  // ----- NEXT STEP -----
   // if the debt position has been correctly created => publish 
-  if (r.status === 201) {
-    // sleep(1);
-    // Publish the debt position.
-    url = `${rootUrl}/organizations/${creditor_institution_code}/debtpositions/${iupd}/publish`;
+  if (r.status !== 200) return; // exit flow if failed
+  url = `${rootUrl}/organizations/${creditor_institution_code}/debtpositions/${iupd}/publish`;
+  r = http.post(url, params);
 
-    r = http.post(url, params);
-
-    //console.log("PublishDebtPosition call - creditor_institution_code = " + creditor_institution_code + ", iupd = " + iupd + ", Status = " + r.status);
-
-    check(r, {
-      'PublishDebtPosition status is 200': (r) => r.status === 200,
-    });
-
-    // if the debt position has been correctly published => pay 
-    if (r.status === 200) {
-      // sleep(1);
-      // Pay Payment Option.
-
-      url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}/pay`;
-
-      payload = JSON.stringify(
-        {
-          "paymentDate": new Date(),
-          "paymentMethod": "bonifico",
-          "pspCompany": "Intesa San Paolo",
-          "idReceipt": "TRN123456789"
-        }
-      );
-
-      r = http.post(url, payload, params);
-
-      //console.log("PayPaymentOption call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", Status = " + r.status);
-
-      check(r, {
-        'PayPaymentOption status is 200': (r) => r.status === 200,
-      });
-
-      // if the payment option has been correctly paid => report
-      if (r.status === 200) {
-        // sleep(1);
-        // Report Transfer.
-        url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}/transfers/${transfer_id}/report`;
-
-        r = http.post(url, params);
-
-        //console.log("ReportTransfer call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", transfer_id = " + transfer_id + ", Status = " + r.status);
-
-        check(r, {
-          'ReportTransfer status is 200': (r) => r.status === 200,
-        });
-
-        // if the transfer has been correctly reported => get
-        if (r.status === 200) {
-          // Get details of a specific payment option.
-
-          url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}`;
-
-          r = http.get(url, params);
-
-          //console.log("GetOrganizationPaymentOption call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", Status = " + r.status);
-
-          check(r, {
-            'GetOrganizationPaymentOption status is 200': (r) => r.status === 200,
-          });
-
-          console.log( "Body: " + r.body);
-
-          check(r, {
-            'GetOrganizationPaymentOption payment option status is reported': (r) => (JSON.parse(r.body)).status === 'PO_REPORTED',
-          });
-
-        }
-      }
-    }
- 
-    // sleep(2);
-  }
+  //console.log("PublishDebtPosition call - creditor_institution_code = " + creditor_institution_code + ", iupd = " + iupd + ", Status = " + r.status);
+  check(r, {
+    'PublishDebtPosition status is 200': (r) => r.status === 200,
+  });
 
 
+  // ----- NEXT STEP -----
+  // if the debt position has been correctly published => pay 
+  if (r.status !== 200) return; // exit flow if failed  
+  
+  // sleep(1);
+  // Pay Payment Option.
+  url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}/pay`;
+  payload = JSON.stringify({
+    "paymentDate": new Date(),
+    "paymentMethod": "bonifico",
+    "pspCompany": "Intesa San Paolo",
+    "idReceipt": "TRN123456789"
+  });
+  r = http.post(url, payload, params);
+
+  //console.log("PayPaymentOption call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", Status = " + r.status);
+  check(r, {
+    'PayPaymentOption status is 200': (r) => r.status === 200,
+  });
+
+
+  // ----- NEXT STEP -----
+  // if the payment option has been correctly paid => report
+  if (r.status !== 200) return; // exit flow if failed  
+
+  // sleep(1);
+  // Report Transfer.
+  url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}/transfers/${transfer_id}/report`;
+  r = http.post(url, params);
+
+  //console.log("ReportTransfer call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", transfer_id = " + transfer_id + ", Status = " + r.status);
+  check(r, {
+    'ReportTransfer status is 200': (r) => r.status === 200,
+  });
+
+
+  // ----- NEXT STEP -----
+  // if the transfer has been correctly reported => get
+  if (r.status !== 200) return; // exit flow if failed  
+
+  // Get details of a specific payment option.
+  url = `${rootUrl}/organizations/${creditor_institution_code}/paymentoptions/${iuv}`;
+  r = http.get(url, params);
+
+  //console.log("GetOrganizationPaymentOption call - creditor_institution_code = " + creditor_institution_code + ", iuv = " + iuv + ", Status = " + r.status);
+  check(r, {
+    'GetOrganizationPaymentOption status is 200': (r) => r.status === 200,
+  });
+  console.log( "Body: " + r.body);
+  
+  check(r, {
+    'GetOrganizationPaymentOption payment option status is reported': (r) => (JSON.parse(r.body)).status === 'PO_REPORTED',
+  });
+
+  // sleep(2);
 }

--- a/gpd/load-test/src/upd_workflow.js
+++ b/gpd/load-test/src/upd_workflow.js
@@ -90,6 +90,7 @@ export default function () {
 
     const payload2 = JSON.parse(payload)
     payload2.civicNumber=999
+    payload2.paymentOption[0].transfer[0].organizationFiscalCode="00011122201"
 
     r = http.put(url,JSON.stringify(payload2), params);
 

--- a/gpd/openapi/openapi.json
+++ b/gpd/openapi/openapi.json
@@ -35,8 +35,8 @@
                 "summary": "Return OK if application is started",
                 "operationId": "healthCheck",
                 "responses": {
-                    "403": {
-                        "description": "Forbidden.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -46,8 +46,26 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "200": {
+                        "description": "OK.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppInfo"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -71,24 +89,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "OK.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AppInfo"
                                 }
                             }
                         }
@@ -145,24 +145,6 @@
                             }
                         }
                     },
-                    "200": {
-                        "description": "Obtained organizations to add and delete.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
-                                }
-                            }
-                        }
-                    },
                     "500": {
                         "description": "Service unavailable.",
                         "headers": {
@@ -177,6 +159,24 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Obtained organizations to add and delete.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
                                 }
                             }
                         }
@@ -331,8 +331,37 @@
                     }
                 ],
                 "responses": {
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "429": {
                         "description": "Too many requests.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -360,37 +389,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "500": {
                         "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -454,6 +454,24 @@
                     "required": true
                 },
                 "responses": {
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "409": {
                         "description": "Conflict: duplicate debt position found.",
                         "headers": {
@@ -483,24 +501,6 @@
                             }
                         }
                     },
-                    "201": {
-                        "description": "Request created.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
                     "500": {
                         "description": "Service unavailable.",
                         "headers": {
@@ -519,8 +519,8 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "Malformed request.",
+                    "201": {
+                        "description": "Request created.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -532,7 +532,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
                                 }
                             }
                         }
@@ -586,24 +586,6 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "Obtained debt position details.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-                                }
-                            }
-                        }
-                    },
                     "401": {
                         "description": "Wrong or missing function key.",
                         "headers": {
@@ -647,6 +629,24 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Obtained debt position details.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                                 }
                             }
                         }
@@ -707,6 +707,24 @@
                     "required": true
                 },
                 "responses": {
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Wrong or missing function key.",
                         "headers": {
@@ -754,42 +772,6 @@
                             }
                         }
                     },
-                    "200": {
-                        "description": "Request updated.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
                     "404": {
                         "description": "No debt position found.",
                         "headers": {
@@ -804,6 +786,24 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request updated.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
                                 }
                             }
                         }
@@ -892,8 +892,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position position found.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -910,8 +910,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1006,6 +1006,24 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "No debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "200": {
                         "description": "Request published.",
                         "headers": {
@@ -1026,24 +1044,6 @@
                     },
                     "409": {
                         "description": "Conflict: debt position is not in invalidable state.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1109,8 +1109,19 @@
                     }
                 ],
                 "responses": {
-                    "409": {
-                        "description": "Conflict: debt position is not in publishable state.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1127,19 +1138,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1174,8 +1174,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "409": {
+                        "description": "Conflict: debt position is not in publishable state.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1365,6 +1365,24 @@
                     "required": true
                 },
                 "responses": {
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Wrong or missing function key.",
                         "headers": {
@@ -1372,6 +1390,24 @@
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable payment option.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1408,42 +1444,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PaymentsModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable payment option.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1525,8 +1525,8 @@
                     "required": true
                 },
                 "responses": {
-                    "422": {
-                        "description": "Unprocessable: not in payable state.",
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1608,8 +1608,8 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "Malformed request.",
+                    "404": {
+                        "description": "No payment option found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1626,8 +1626,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No payment option found.",
+                    "422": {
+                        "description": "Unprocessable: not in payable state.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1702,6 +1702,24 @@
                     }
                 ],
                 "responses": {
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "200": {
                         "description": "Request reported.",
                         "headers": {
@@ -1769,24 +1787,6 @@
                     },
                     "500": {
                         "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -2045,6 +2045,11 @@
                     "fee": {
                         "type": "integer",
                         "format": "int64"
+                    },
+                    "notificationFee": {
+                        "type": "integer",
+                        "format": "int64",
+                        "readOnly": true
                     },
                     "transfer": {
                         "type": "array",

--- a/gpd/openapi/openapi.json
+++ b/gpd/openapi/openapi.json
@@ -1,2462 +1,2471 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-        "title": "PagoPA API Debt Position",
-        "description": "Progetto Gestione Posizioni Debitorie",
-        "termsOfService": "https://www.pagopa.gov.it/",
-        "version": "0.4.5"
-    },
-    "servers": [
-        {
-            "url": "http://localhost:8080",
-            "description": "Generated server url"
-        }
-    ],
-    "tags": [
-        {
-            "name": "Debt Positions API"
-        },
-        {
-            "name": "Configurations API"
-        },
-        {
-            "name": "Debt Position Actions API"
-        },
-        {
-            "name": "Payments API"
-        }
-    ],
-    "paths": {
-        "/info": {
-            "get": {
-                "tags": [
-                    "Home"
-                ],
-                "summary": "Return OK if application is started",
-                "operationId": "healthCheck",
-                "responses": {
-                    "200": {
-                        "description": "OK.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AppInfo"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations": {
-            "get": {
-                "tags": [
-                    "Configurations API"
-                ],
-                "summary": "Return the list of the organizations.",
-                "operationId": "getOrganizations",
-                "parameters": [
-                    {
-                        "name": "since",
-                        "in": "query",
-                        "description": "Filter from date (use the format yyyy-MM-dd)",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Obtained organizations to add and delete.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/debtpositions": {
-            "get": {
-                "tags": [
-                    "Debt Positions API"
-                ],
-                "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-                "operationId": "getOrganizationDebtPositions",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Number of elements on one page. Default = 50",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32",
-                            "default": 50
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Page number. Page value starts from 0",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
-                    },
-                    {
-                        "name": "due_date_from",
-                        "in": "query",
-                        "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "due_date_to",
-                        "in": "query",
-                        "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "payment_date_from",
-                        "in": "query",
-                        "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "payment_date_to",
-                        "in": "query",
-                        "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "date"
-                        }
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Filter by debt position status",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "DRAFT",
-                                "PUBLISHED",
-                                "VALID",
-                                "INVALID",
-                                "EXPIRED",
-                                "PARTIALLY_PAID",
-                                "PAID",
-                                "REPORTED"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "orderby",
-                        "in": "query",
-                        "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "default": "COMPANY_NAME",
-                            "enum": [
-                                "INSERTED_DATE",
-                                "IUPD",
-                                "STATUS",
-                                "COMPANY_NAME"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "ordering",
-                        "in": "query",
-                        "description": "Direction of ordering",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "default": "DESC",
-                            "enum": [
-                                "ASC",
-                                "DESC"
-                            ]
-                        }
-                    }
-                ],
-                "responses": {
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Too many requests.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Obtained all organization payment positions.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionsInfo"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "post": {
-                "tags": [
-                    "Debt Positions API"
-                ],
-                "summary": "The Organization creates a debt Position.",
-                "operationId": "createPosition",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "toPublish",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PaymentPositionModel"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "201": {
-                        "description": "Request created.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: duplicate debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-            "get": {
-                "tags": [
-                    "Debt Positions API"
-                ],
-                "summary": "Return the details of a specific debt position.",
-                "operationId": "getOrganizationDebtPositionByIUPD",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iupd",
-                        "in": "path",
-                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Obtained debt position details.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "put": {
-                "tags": [
-                    "Debt Positions API"
-                ],
-                "summary": "The Organization updates a debt position ",
-                "operationId": "updatePosition",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iupd",
-                        "in": "path",
-                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PaymentPositionModel"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Request updated.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "delete": {
-                "tags": [
-                    "Debt Positions API"
-                ],
-                "summary": "The Organization deletes a debt position",
-                "operationId": "deletePosition",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iupd",
-                        "in": "path",
-                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Operation completed successfully.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-            "post": {
-                "tags": [
-                    "Debt Position Actions API"
-                ],
-                "summary": "The Organization invalidate a debt Position.",
-                "operationId": "invalidatePosition",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iupd",
-                        "in": "path",
-                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Request published.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: debt position is not in invalidable state.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-            "post": {
-                "tags": [
-                    "Debt Position Actions API"
-                ],
-                "summary": "The Organization publish a debt Position.",
-                "operationId": "publishPosition",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iupd",
-                        "in": "path",
-                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: debt position is not in publishable state.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Request published.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentPositionModel"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}": {
-            "get": {
-                "tags": [
-                    "Payments API"
-                ],
-                "summary": "Return the details of a specific payment option.",
-                "operationId": "getOrganizationPaymentOptionByIUV",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iuv",
-                        "in": "path",
-                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Obtained payment option details.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No payment option found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay": {
-            "post": {
-                "tags": [
-                    "Payments API"
-                ],
-                "summary": "The Organization paid a payment option.",
-                "operationId": "payPaymentOption",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iuv",
-                        "in": "path",
-                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PayPaymentOptionModel"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "200": {
-                        "description": "Request paid.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentsModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No payment option found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable: not in payable state.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
-            "post": {
-                "tags": [
-                    "Payments API"
-                ],
-                "summary": "The organization reports a transaction.",
-                "operationId": "reportTransfer",
-                "parameters": [
-                    {
-                        "name": "organizationfiscalcode",
-                        "in": "path",
-                        "description": "Organization fiscal code, the fiscal code of the Organization.",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "iuv",
-                        "in": "path",
-                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "transferid",
-                        "in": "path",
-                        "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request reported.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No transfer found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "ApiKey": []
-                    },
-                    {
-                        "Authorization": []
-                    }
-                ]
-            },
-            "parameters": [
-                {
-                    "name": "X-Request-Id",
-                    "in": "header",
-                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ]
-        }
-    },
-    "components": {
-        "schemas": {
-            "PaymentOptionModel": {
-                "required": [
-                    "amount",
-                    "dueDate",
-                    "isPartialPayment",
-                    "iuv"
-                ],
-                "type": "object",
-                "properties": {
-                    "iuv": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isPartialPayment": {
-                        "type": "boolean"
-                    },
-                    "dueDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "retentionDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "fee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "transfer": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TransferModel"
-                        }
-                    }
-                }
-            },
-            "PaymentPositionModel": {
-                "required": [
-                    "companyName",
-                    "fiscalCode",
-                    "fullName",
-                    "iupd",
-                    "type"
-                ],
-                "type": "object",
-                "properties": {
-                    "iupd": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "F",
-                            "G"
-                        ]
-                    },
-                    "fiscalCode": {
-                        "type": "string"
-                    },
-                    "fullName": {
-                        "type": "string"
-                    },
-                    "streetName": {
-                        "type": "string"
-                    },
-                    "civicNumber": {
-                        "type": "string"
-                    },
-                    "postalCode": {
-                        "type": "string"
-                    },
-                    "city": {
-                        "type": "string"
-                    },
-                    "province": {
-                        "type": "string"
-                    },
-                    "region": {
-                        "type": "string"
-                    },
-                    "country": {
-                        "pattern": "[A-Z]{2}",
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    },
-                    "switchToExpired": {
-                        "type": "boolean",
-                        "description": "feature flag to enable the debt position to expire after the due date",
-                        "example": false,
-                        "default": false
-                    },
-                    "companyName": {
-                        "type": "string"
-                    },
-                    "officeName": {
-                        "type": "string"
-                    },
-                    "validityDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time",
-                        "readOnly": true
-                    },
-                    "status": {
-                        "type": "string",
-                        "readOnly": true,
-                        "enum": [
-                            "DRAFT",
-                            "PUBLISHED",
-                            "VALID",
-                            "INVALID",
-                            "EXPIRED",
-                            "PARTIALLY_PAID",
-                            "PAID",
-                            "REPORTED"
-                        ]
-                    },
-                    "paymentOption": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PaymentOptionModel"
-                        }
-                    }
-                }
-            },
-            "Stamp": {
-                "required": [
-                    "hashDocument",
-                    "provincialResidence",
-                    "stampType"
-                ],
-                "type": "object",
-                "properties": {
-                    "hashDocument": {
-                        "type": "string",
-                        "description": "Document hash"
-                    },
-                    "stampType": {
-                        "maxLength": 2,
-                        "minLength": 2,
-                        "type": "string",
-                        "description": "The type of the stamp"
-                    },
-                    "provincialResidence": {
-                        "pattern": "[A-Z]{2}",
-                        "type": "string",
-                        "description": "The provincial of the residence",
-                        "example": "RM"
-                    }
-                }
-            },
-            "TransferModel": {
-                "required": [
-                    "amount",
-                    "category",
-                    "idTransfer",
-                    "remittanceInformation"
-                ],
-                "type": "object",
-                "properties": {
-                    "idTransfer": {
-                        "type": "string",
-                        "enum": [
-                            "1",
-                            "2",
-                            "3",
-                            "4",
-                            "5"
-                        ]
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "organizationFiscalCode": {
-                        "type": "string",
-                        "description": "Fiscal code related to the organization targeted by this transfer.",
-                        "example": "00000000000"
-                    },
-                    "remittanceInformation": {
-                        "type": "string"
-                    },
-                    "category": {
-                        "type": "string"
-                    },
-                    "iban": {
-                        "type": "string",
-                        "description": "mutual exclusive with postalIban and stamp",
-                        "example": "IT0000000000000000000000000"
-                    },
-                    "postalIban": {
-                        "type": "string",
-                        "description": "mutual exclusive with iban and stamp",
-                        "example": "IT0000000000000000000000000"
-                    },
-                    "stamp": {
-                        "$ref": "#/components/schemas/Stamp"
-                    }
-                }
-            },
-            "ProblemJson": {
-                "type": "object",
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
-                    },
-                    "status": {
-                        "maximum": 600,
-                        "minimum": 100,
-                        "type": "integer",
-                        "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-                        "format": "int32",
-                        "example": 200
-                    },
-                    "detail": {
-                        "type": "string",
-                        "description": "A human readable explanation specific to this occurrence of the problem.",
-                        "example": "There was an error processing the request"
-                    }
-                }
-            },
-            "PaymentsTransferModelResponse": {
-                "type": "object",
-                "properties": {
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "idTransfer": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "remittanceInformation": {
-                        "type": "string"
-                    },
-                    "category": {
-                        "type": "string"
-                    },
-                    "iban": {
-                        "type": "string"
-                    },
-                    "postalIban": {
-                        "type": "string"
-                    },
-                    "stamp": {
-                        "$ref": "#/components/schemas/Stamp"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "T_UNREPORTED",
-                            "T_REPORTED"
-                        ]
-                    },
-                    "lastUpdatedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            },
-            "PayPaymentOptionModel": {
-                "required": [
-                    "idReceipt",
-                    "pspCompany"
-                ],
-                "type": "object",
-                "properties": {
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentMethod": {
-                        "type": "string"
-                    },
-                    "pspCompany": {
-                        "type": "string"
-                    },
-                    "idReceipt": {
-                        "type": "string"
-                    },
-                    "fee": {
-                        "type": "string"
-                    }
-                }
-            },
-            "PaymentsModelResponse": {
-                "type": "object",
-                "properties": {
-                    "iuv": {
-                        "type": "string"
-                    },
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isPartialPayment": {
-                        "type": "boolean"
-                    },
-                    "dueDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "retentionDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "reportingDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentMethod": {
-                        "type": "string"
-                    },
-                    "fee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "pspCompany": {
-                        "type": "string"
-                    },
-                    "idReceipt": {
-                        "type": "string"
-                    },
-                    "idFlowReporting": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "PO_UNPAID",
-                            "PO_PAID",
-                            "PO_PARTIALLY_REPORTED",
-                            "PO_REPORTED"
-                        ]
-                    },
-                    "lastUpdatedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "transfer": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                        }
-                    }
-                }
-            },
-            "OrganizationListModelResponse": {
-                "type": "object",
-                "properties": {
-                    "add": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/OrganizationModelResponse"
-                        }
-                    },
-                    "delete": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/OrganizationModelResponse"
-                        }
-                    }
-                }
-            },
-            "OrganizationModelResponse": {
-                "type": "object",
-                "properties": {
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    }
-                }
-            },
-            "PaymentsWithDebtorInfoModelResponse": {
-                "type": "object",
-                "properties": {
-                    "iuv": {
-                        "type": "string"
-                    },
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isPartialPayment": {
-                        "type": "boolean"
-                    },
-                    "dueDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "retentionDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "reportingDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentMethod": {
-                        "type": "string"
-                    },
-                    "fee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "pspCompany": {
-                        "type": "string"
-                    },
-                    "idReceipt": {
-                        "type": "string"
-                    },
-                    "idFlowReporting": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "PO_UNPAID",
-                            "PO_PAID",
-                            "PO_PARTIALLY_REPORTED",
-                            "PO_REPORTED"
-                        ]
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "F",
-                            "G"
-                        ]
-                    },
-                    "fiscalCode": {
-                        "type": "string"
-                    },
-                    "fullName": {
-                        "type": "string"
-                    },
-                    "streetName": {
-                        "type": "string"
-                    },
-                    "civicNumber": {
-                        "type": "string"
-                    },
-                    "postalCode": {
-                        "type": "string"
-                    },
-                    "city": {
-                        "type": "string"
-                    },
-                    "province": {
-                        "type": "string"
-                    },
-                    "region": {
-                        "type": "string"
-                    },
-                    "country": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "phone": {
-                        "type": "string"
-                    },
-                    "companyName": {
-                        "type": "string"
-                    },
-                    "officeName": {
-                        "type": "string"
-                    },
-                    "debtPositionStatus": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "PUBLISHED",
-                            "VALID",
-                            "INVALID",
-                            "EXPIRED",
-                            "PARTIALLY_PAID",
-                            "PAID",
-                            "REPORTED"
-                        ]
-                    },
-                    "transfer": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                        }
-                    }
-                }
-            },
-            "PageInfo": {
-                "required": [
-                    "items_found",
-                    "limit",
-                    "page",
-                    "total_pages"
-                ],
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer",
-                        "description": "Page number",
-                        "format": "int32"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Required number of items per page",
-                        "format": "int32"
-                    },
-                    "items_found": {
-                        "type": "integer",
-                        "description": "Number of items found. (The last page may have fewer elements than required)",
-                        "format": "int32"
-                    },
-                    "total_pages": {
-                        "type": "integer",
-                        "description": "Total number of pages",
-                        "format": "int32"
-                    }
-                }
-            },
-            "PaymentOptionModelResponse": {
-                "type": "object",
-                "properties": {
-                    "iuv": {
-                        "type": "string"
-                    },
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isPartialPayment": {
-                        "type": "boolean"
-                    },
-                    "dueDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "retentionDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "reportingDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentMethod": {
-                        "type": "string"
-                    },
-                    "fee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "pspCompany": {
-                        "type": "string"
-                    },
-                    "idReceipt": {
-                        "type": "string"
-                    },
-                    "idFlowReporting": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "PO_UNPAID",
-                            "PO_PAID",
-                            "PO_PARTIALLY_REPORTED",
-                            "PO_REPORTED"
-                        ]
-                    },
-                    "lastUpdatedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "transfer": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/TransferModelResponse"
-                        }
-                    }
-                }
-            },
-            "PaymentPositionModelBaseResponse": {
-                "type": "object",
-                "properties": {
-                    "iupd": {
-                        "type": "string"
-                    },
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "F",
-                            "G"
-                        ]
-                    },
-                    "companyName": {
-                        "type": "string"
-                    },
-                    "officeName": {
-                        "type": "string"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "publishDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "validityDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "DRAFT",
-                            "PUBLISHED",
-                            "VALID",
-                            "INVALID",
-                            "EXPIRED",
-                            "PARTIALLY_PAID",
-                            "PAID",
-                            "REPORTED"
-                        ]
-                    },
-                    "lastUpdatedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "paymentOption": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PaymentOptionModelResponse"
-                        }
-                    }
-                }
-            },
-            "PaymentPositionsInfo": {
-                "required": [
-                    "page_info",
-                    "payment_position_list"
-                ],
-                "type": "object",
-                "properties": {
-                    "payment_position_list": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-                        }
-                    },
-                    "page_info": {
-                        "$ref": "#/components/schemas/PageInfo"
-                    }
-                }
-            },
-            "TransferModelResponse": {
-                "type": "object",
-                "properties": {
-                    "organizationFiscalCode": {
-                        "type": "string"
-                    },
-                    "idTransfer": {
-                        "type": "string"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "remittanceInformation": {
-                        "type": "string"
-                    },
-                    "category": {
-                        "type": "string"
-                    },
-                    "iban": {
-                        "type": "string"
-                    },
-                    "postalIban": {
-                        "type": "string"
-                    },
-                    "stamp": {
-                        "$ref": "#/components/schemas/Stamp"
-                    },
-                    "insertedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "T_UNREPORTED",
-                            "T_REPORTED"
-                        ]
-                    },
-                    "lastUpdatedDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            },
-            "AppInfo": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "securitySchemes": {
-            "ApiKey": {
-                "type": "apiKey",
-                "description": "The API key to access this function app.",
-                "name": "Ocp-Apim-Subscription-Key",
-                "in": "header"
-            },
-            "Authorization": {
-                "type": "http",
-                "description": "JWT token get after Azure Login",
-                "scheme": "bearer",
-                "bearerFormat": "JWT"
-            }
-        }
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.4.6"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Generated server url"
     }
+  ],
+  "tags": [
+    {
+      "name": "Debt Positions API"
+    },
+    {
+      "name": "Configurations API"
+    },
+    {
+      "name": "Debt Position Actions API"
+    },
+    {
+      "name": "Payments API"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations": {
+      "get": {
+        "tags": [
+          "Configurations API"
+        ],
+        "summary": "Return the list of the organizations.",
+        "operationId": "getOrganizations",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Filter from date (use the format yyyy-MM-dd)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained organizations to add and delete.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationListModelResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "INVALID",
+                "EXPIRED",
+                "PARTIALLY_PAID",
+                "PAID",
+                "REPORTED"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "COMPANY_NAME",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates a debt Position.",
+        "operationId": "createPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Request updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization invalidate a debt Position.",
+        "operationId": "invalidatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: debt position is not in invalidable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}": {
+      "get": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "Return the details of a specific payment option.",
+        "operationId": "getOrganizationPaymentOptionByIUV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Obtained payment option details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The Organization paid a payment option.",
+        "operationId": "payPaymentOption",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PayPaymentOptionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Request paid.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable: not in payable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization reports a transaction.",
+        "operationId": "reportTransfer",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "transferid",
+            "in": "path",
+            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request reported.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No transfer found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          },
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  },
+  "components": {
+    "schemas": {
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "iuv": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isPartialPayment": {
+            "type": "boolean"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
+            }
+          }
+        }
+      },
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
+          }
+        }
+      },
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "type": "string",
+            "description": "Document hash"
+          },
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with postalIban and stamp",
+            "example": "IT0000000000000000000000000"
+          },
+          "postalIban": {
+            "type": "string",
+            "description": "mutual exclusive with iban and stamp",
+            "example": "IT0000000000000000000000000"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          }
+        }
+      },
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          },
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
+          }
+        }
+      },
+      "PaymentsTransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PayPaymentOptionModel": {
+        "required": [
+          "idReceipt",
+          "pspCompany"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentMethod": {
+            "type": "string"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "string"
+          }
+        }
+      },
+      "PaymentsModelResponse": {
+        "type": "object",
+        "properties": {
+          "iuv": {
+            "type": "string"
+          },
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isPartialPayment": {
+            "type": "boolean"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+            }
+          }
+        }
+      },
+      "OrganizationListModelResponse": {
+        "type": "object",
+        "properties": {
+          "add": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationModelResponse"
+            }
+          },
+          "delete": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationModelResponse"
+            }
+          }
+        }
+      },
+      "OrganizationModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          }
+        }
+      },
+      "PaymentsWithDebtorInfoModelResponse": {
+        "type": "object",
+        "properties": {
+          "iuv": {
+            "type": "string"
+          },
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isPartialPayment": {
+            "type": "boolean"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "debtPositionStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+            }
+          }
+        }
+      },
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
+          },
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
+          }
+        }
+      },
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "iuv": {
+            "type": "string"
+          },
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isPartialPayment": {
+            "type": "boolean"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
+            }
+          }
+        }
+      },
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
+          },
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+            }
+          }
+        }
+      },
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            }
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
+      },
+      "Authorization": {
+        "type": "http",
+        "description": "JWT token get after Azure Login",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
 }

--- a/gpd/openapi/openapi.json
+++ b/gpd/openapi/openapi.json
@@ -1,15 +1,2647 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.4.6"
-  },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Generated server url"
+    "openapi": "3.0.1",
+    "info": {
+        "title": "PagoPA API Debt Position",
+        "description": "Progetto Gestione Posizioni Debitorie",
+        "termsOfService": "https://www.pagopa.gov.it/",
+        "version": "0.4.6"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080",
+            "description": "Generated server url"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Debt Positions API"
+        },
+        {
+            "name": "Configurations API"
+        },
+        {
+            "name": "Debt Position Actions API"
+        },
+        {
+            "name": "Payments API"
+        }
+    ],
+    "paths": {
+        "/info": {
+            "get": {
+                "tags": [
+                    "Home"
+                ],
+                "summary": "Return OK if application is started",
+                "operationId": "healthCheck",
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "OK.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppInfo"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations": {
+            "get": {
+                "tags": [
+                    "Configurations API"
+                ],
+                "summary": "Return the list of the organizations.",
+                "operationId": "getOrganizations",
+                "parameters": [
+                    {
+                        "name": "since",
+                        "in": "query",
+                        "description": "Filter from date (use the format yyyy-MM-dd)",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Obtained organizations to add and delete.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/debtpositions": {
+            "get": {
+                "tags": [
+                    "Debt Positions API"
+                ],
+                "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+                "operationId": "getOrganizationDebtPositions",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of elements on one page. Default = 50",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 50
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number. Page value starts from 0",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    {
+                        "name": "due_date_from",
+                        "in": "query",
+                        "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "due_date_to",
+                        "in": "query",
+                        "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "payment_date_from",
+                        "in": "query",
+                        "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "payment_date_to",
+                        "in": "query",
+                        "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by debt position status",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "DRAFT",
+                                "PUBLISHED",
+                                "VALID",
+                                "INVALID",
+                                "EXPIRED",
+                                "PARTIALLY_PAID",
+                                "PAID",
+                                "REPORTED"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "orderby",
+                        "in": "query",
+                        "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "COMPANY_NAME",
+                            "enum": [
+                                "INSERTED_DATE",
+                                "IUPD",
+                                "STATUS",
+                                "COMPANY_NAME"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "in": "query",
+                        "description": "Direction of ordering",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "DESC",
+                            "enum": [
+                                "ASC",
+                                "DESC"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Obtained all organization payment positions.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionsInfo"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Debt Positions API"
+                ],
+                "summary": "The Organization creates a debt Position.",
+                "operationId": "createPosition",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "toPublish",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PaymentPositionModel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: duplicate debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Request created.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+            "get": {
+                "tags": [
+                    "Debt Positions API"
+                ],
+                "summary": "Return the details of a specific debt position.",
+                "operationId": "getOrganizationDebtPositionByIUPD",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iupd",
+                        "in": "path",
+                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Obtained debt position details.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Debt Positions API"
+                ],
+                "summary": "The Organization updates a debt position ",
+                "operationId": "updatePosition",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iupd",
+                        "in": "path",
+                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PaymentPositionModel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request updated.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Debt Positions API"
+                ],
+                "summary": "The Organization deletes a debt position",
+                "operationId": "deletePosition",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iupd",
+                        "in": "path",
+                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Operation completed successfully.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+            "post": {
+                "tags": [
+                    "Debt Position Actions API"
+                ],
+                "summary": "The Organization invalidate a debt Position.",
+                "operationId": "invalidatePosition",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iupd",
+                        "in": "path",
+                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: debt position is not in invalidable state.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request published.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+            "post": {
+                "tags": [
+                    "Debt Position Actions API"
+                ],
+                "summary": "The Organization publish a debt Position.",
+                "operationId": "publishPosition",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iupd",
+                        "in": "path",
+                        "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: debt position is not in publishable state.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request published.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentPositionModel"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}": {
+            "get": {
+                "tags": [
+                    "Payments API"
+                ],
+                "summary": "Return the details of a specific payment option.",
+                "operationId": "getOrganizationPaymentOptionByIUV",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iuv",
+                        "in": "path",
+                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Obtained payment option details.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationfee": {
+            "put": {
+                "tags": [
+                    "Payments API"
+                ],
+                "summary": "The organization updates the notification fee of a payment option.",
+                "operationId": "updateNotificationFee",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iuv",
+                        "in": "path",
+                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable payment option.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request updated.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentsModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay": {
+            "post": {
+                "tags": [
+                    "Payments API"
+                ],
+                "summary": "The Organization paid a payment option.",
+                "operationId": "payPaymentOption",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iuv",
+                        "in": "path",
+                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PayPaymentOptionModel"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable: not in payable state.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request paid.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentsModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
+            "post": {
+                "tags": [
+                    "Payments API"
+                ],
+                "summary": "The organization reports a transaction.",
+                "operationId": "reportTransfer",
+                "parameters": [
+                    {
+                        "name": "organizationfiscalcode",
+                        "in": "path",
+                        "description": "Organization fiscal code, the fiscal code of the Organization.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "iuv",
+                        "in": "path",
+                        "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "transferid",
+                        "in": "path",
+                        "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Request reported.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No transfer found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "Authorization": []
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "name": "X-Request-Id",
+                    "in": "header",
+                    "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        }
+    },
+    "components": {
+        "schemas": {
+            "NotificationFeeUpdateModel": {
+                "required": [
+                    "notificationFee"
+                ],
+                "type": "object",
+                "properties": {
+                    "notificationFee": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "ProblemJson": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+                    },
+                    "status": {
+                        "maximum": 600,
+                        "minimum": 100,
+                        "type": "integer",
+                        "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+                        "format": "int32",
+                        "example": 200
+                    },
+                    "detail": {
+                        "type": "string",
+                        "description": "A human readable explanation specific to this occurrence of the problem.",
+                        "example": "There was an error processing the request"
+                    }
+                }
+            },
+            "PaymentsModelResponse": {
+                "type": "object",
+                "properties": {
+                    "iuv": {
+                        "type": "string"
+                    },
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "isPartialPayment": {
+                        "type": "boolean"
+                    },
+                    "dueDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "retentionDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reportingDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentMethod": {
+                        "type": "string"
+                    },
+                    "fee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "notificationFee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pspCompany": {
+                        "type": "string"
+                    },
+                    "idReceipt": {
+                        "type": "string"
+                    },
+                    "idFlowReporting": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PO_UNPAID",
+                            "PO_PAID",
+                            "PO_PARTIALLY_REPORTED",
+                            "PO_REPORTED"
+                        ]
+                    },
+                    "lastUpdatedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "transfer": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+                        }
+                    }
+                }
+            },
+            "PaymentsTransferModelResponse": {
+                "type": "object",
+                "properties": {
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "idTransfer": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remittanceInformation": {
+                        "type": "string"
+                    },
+                    "category": {
+                        "type": "string"
+                    },
+                    "iban": {
+                        "type": "string"
+                    },
+                    "postalIban": {
+                        "type": "string"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "T_UNREPORTED",
+                            "T_REPORTED"
+                        ]
+                    },
+                    "lastUpdatedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "Stamp": {
+                "required": [
+                    "hashDocument",
+                    "provincialResidence",
+                    "stampType"
+                ],
+                "type": "object",
+                "properties": {
+                    "hashDocument": {
+                        "type": "string",
+                        "description": "Document hash"
+                    },
+                    "stampType": {
+                        "maxLength": 2,
+                        "minLength": 2,
+                        "type": "string",
+                        "description": "The type of the stamp"
+                    },
+                    "provincialResidence": {
+                        "pattern": "[A-Z]{2}",
+                        "type": "string",
+                        "description": "The provincial of the residence",
+                        "example": "RM"
+                    }
+                }
+            },
+            "PaymentOptionModel": {
+                "required": [
+                    "amount",
+                    "dueDate",
+                    "isPartialPayment",
+                    "iuv"
+                ],
+                "type": "object",
+                "properties": {
+                    "iuv": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "isPartialPayment": {
+                        "type": "boolean"
+                    },
+                    "dueDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "retentionDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "fee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "transfer": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TransferModel"
+                        }
+                    }
+                }
+            },
+            "PaymentPositionModel": {
+                "required": [
+                    "companyName",
+                    "fiscalCode",
+                    "fullName",
+                    "iupd",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "iupd": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "F",
+                            "G"
+                        ]
+                    },
+                    "fiscalCode": {
+                        "type": "string"
+                    },
+                    "fullName": {
+                        "type": "string"
+                    },
+                    "streetName": {
+                        "type": "string"
+                    },
+                    "civicNumber": {
+                        "type": "string"
+                    },
+                    "postalCode": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "province": {
+                        "type": "string"
+                    },
+                    "region": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "pattern": "[A-Z]{2}",
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "switchToExpired": {
+                        "type": "boolean",
+                        "description": "feature flag to enable the debt position to expire after the due date",
+                        "example": false,
+                        "default": false
+                    },
+                    "companyName": {
+                        "type": "string"
+                    },
+                    "officeName": {
+                        "type": "string"
+                    },
+                    "validityDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "readOnly": true,
+                        "enum": [
+                            "DRAFT",
+                            "PUBLISHED",
+                            "VALID",
+                            "INVALID",
+                            "EXPIRED",
+                            "PARTIALLY_PAID",
+                            "PAID",
+                            "REPORTED"
+                        ]
+                    },
+                    "paymentOption": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentOptionModel"
+                        }
+                    }
+                }
+            },
+            "TransferModel": {
+                "required": [
+                    "amount",
+                    "category",
+                    "idTransfer",
+                    "remittanceInformation"
+                ],
+                "type": "object",
+                "properties": {
+                    "idTransfer": {
+                        "type": "string",
+                        "enum": [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5"
+                        ]
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "organizationFiscalCode": {
+                        "type": "string",
+                        "description": "Fiscal code related to the organization targeted by this transfer.",
+                        "example": "00000000000"
+                    },
+                    "remittanceInformation": {
+                        "type": "string"
+                    },
+                    "category": {
+                        "type": "string"
+                    },
+                    "iban": {
+                        "type": "string",
+                        "description": "mutual exclusive with postalIban and stamp",
+                        "example": "IT0000000000000000000000000"
+                    },
+                    "postalIban": {
+                        "type": "string",
+                        "description": "mutual exclusive with iban and stamp",
+                        "example": "IT0000000000000000000000000"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
+                    }
+                }
+            },
+            "PayPaymentOptionModel": {
+                "required": [
+                    "idReceipt",
+                    "pspCompany"
+                ],
+                "type": "object",
+                "properties": {
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentMethod": {
+                        "type": "string"
+                    },
+                    "pspCompany": {
+                        "type": "string"
+                    },
+                    "idReceipt": {
+                        "type": "string"
+                    },
+                    "fee": {
+                        "type": "string"
+                    }
+                }
+            },
+            "OrganizationListModelResponse": {
+                "type": "object",
+                "properties": {
+                    "add": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationModelResponse"
+                        }
+                    },
+                    "delete": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationModelResponse"
+                        }
+                    }
+                }
+            },
+            "OrganizationModelResponse": {
+                "type": "object",
+                "properties": {
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    }
+                }
+            },
+            "PaymentsWithDebtorInfoModelResponse": {
+                "type": "object",
+                "properties": {
+                    "iuv": {
+                        "type": "string"
+                    },
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "isPartialPayment": {
+                        "type": "boolean"
+                    },
+                    "dueDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "retentionDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reportingDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentMethod": {
+                        "type": "string"
+                    },
+                    "fee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "notificationFee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pspCompany": {
+                        "type": "string"
+                    },
+                    "idReceipt": {
+                        "type": "string"
+                    },
+                    "idFlowReporting": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PO_UNPAID",
+                            "PO_PAID",
+                            "PO_PARTIALLY_REPORTED",
+                            "PO_REPORTED"
+                        ]
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "F",
+                            "G"
+                        ]
+                    },
+                    "fiscalCode": {
+                        "type": "string"
+                    },
+                    "fullName": {
+                        "type": "string"
+                    },
+                    "streetName": {
+                        "type": "string"
+                    },
+                    "civicNumber": {
+                        "type": "string"
+                    },
+                    "postalCode": {
+                        "type": "string"
+                    },
+                    "city": {
+                        "type": "string"
+                    },
+                    "province": {
+                        "type": "string"
+                    },
+                    "region": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "companyName": {
+                        "type": "string"
+                    },
+                    "officeName": {
+                        "type": "string"
+                    },
+                    "debtPositionStatus": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "PUBLISHED",
+                            "VALID",
+                            "INVALID",
+                            "EXPIRED",
+                            "PARTIALLY_PAID",
+                            "PAID",
+                            "REPORTED"
+                        ]
+                    },
+                    "transfer": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+                        }
+                    }
+                }
+            },
+            "PageInfo": {
+                "required": [
+                    "items_found",
+                    "limit",
+                    "page",
+                    "total_pages"
+                ],
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number",
+                        "format": "int32"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Required number of items per page",
+                        "format": "int32"
+                    },
+                    "items_found": {
+                        "type": "integer",
+                        "description": "Number of items found. (The last page may have fewer elements than required)",
+                        "format": "int32"
+                    },
+                    "total_pages": {
+                        "type": "integer",
+                        "description": "Total number of pages",
+                        "format": "int32"
+                    }
+                }
+            },
+            "PaymentOptionModelResponse": {
+                "type": "object",
+                "properties": {
+                    "iuv": {
+                        "type": "string"
+                    },
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "isPartialPayment": {
+                        "type": "boolean"
+                    },
+                    "dueDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "retentionDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "reportingDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentMethod": {
+                        "type": "string"
+                    },
+                    "fee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "notificationFee": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pspCompany": {
+                        "type": "string"
+                    },
+                    "idReceipt": {
+                        "type": "string"
+                    },
+                    "idFlowReporting": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PO_UNPAID",
+                            "PO_PAID",
+                            "PO_PARTIALLY_REPORTED",
+                            "PO_REPORTED"
+                        ]
+                    },
+                    "lastUpdatedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "transfer": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TransferModelResponse"
+                        }
+                    }
+                }
+            },
+            "PaymentPositionModelBaseResponse": {
+                "type": "object",
+                "properties": {
+                    "iupd": {
+                        "type": "string"
+                    },
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "F",
+                            "G"
+                        ]
+                    },
+                    "companyName": {
+                        "type": "string"
+                    },
+                    "officeName": {
+                        "type": "string"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "publishDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "validityDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "DRAFT",
+                            "PUBLISHED",
+                            "VALID",
+                            "INVALID",
+                            "EXPIRED",
+                            "PARTIALLY_PAID",
+                            "PAID",
+                            "REPORTED"
+                        ]
+                    },
+                    "lastUpdatedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "paymentOption": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentOptionModelResponse"
+                        }
+                    }
+                }
+            },
+            "PaymentPositionsInfo": {
+                "required": [
+                    "page_info",
+                    "payment_position_list"
+                ],
+                "type": "object",
+                "properties": {
+                    "payment_position_list": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+                        }
+                    },
+                    "page_info": {
+                        "$ref": "#/components/schemas/PageInfo"
+                    }
+                }
+            },
+            "TransferModelResponse": {
+                "type": "object",
+                "properties": {
+                    "organizationFiscalCode": {
+                        "type": "string"
+                    },
+                    "idTransfer": {
+                        "type": "string"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remittanceInformation": {
+                        "type": "string"
+                    },
+                    "category": {
+                        "type": "string"
+                    },
+                    "iban": {
+                        "type": "string"
+                    },
+                    "postalIban": {
+                        "type": "string"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
+                    },
+                    "insertedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "T_UNREPORTED",
+                            "T_REPORTED"
+                        ]
+                    },
+                    "lastUpdatedDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "AppInfo": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "ApiKey": {
+                "type": "apiKey",
+                "description": "The API key to access this function app.",
+                "name": "Ocp-Apim-Subscription-Key",
+                "in": "header"
+            },
+            "Authorization": {
+                "type": "http",
+                "description": "JWT token get after Azure Login",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
+        }
     }
   ],
   "tags": [

--- a/gpd/openapi/openapi.json
+++ b/gpd/openapi/openapi.json
@@ -4,11 +4,11 @@
         "title": "PagoPA API Debt Position",
         "description": "Progetto Gestione Posizioni Debitorie",
         "termsOfService": "https://www.pagopa.gov.it/",
-        "version": "0.4.6"
+        "version": "0.4.6-2"
     },
     "servers": [
         {
-            "url": "http://localhost:8080",
+            "url": "http://localhost:8085",
             "description": "Generated server url"
         }
     ],
@@ -35,8 +35,8 @@
                 "summary": "Return OK if application is started",
                 "operationId": "healthCheck",
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "403": {
+                        "description": "Forbidden.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -46,20 +46,13 @@
                             }
                         }
                     },
-                    "200": {
-                        "description": "OK.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AppInfo"
                                 }
                             }
                         }
@@ -82,13 +75,20 @@
                             }
                         }
                     },
-                    "403": {
-                        "description": "Forbidden.",
+                    "200": {
+                        "description": "OK.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppInfo"
                                 }
                             }
                         }
@@ -331,17 +331,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "429": {
                         "description": "Too many requests.",
                         "headers": {
@@ -371,8 +360,19 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "Malformed request.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -389,8 +389,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -454,35 +454,6 @@
                     "required": true
                 },
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
                     "409": {
                         "description": "Conflict: duplicate debt position found.",
                         "headers": {
@@ -497,6 +468,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -521,6 +503,24 @@
                     },
                     "500": {
                         "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -615,8 +615,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -633,8 +633,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -685,6 +685,15 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "toPublish",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 ],
                 "requestBody": {
@@ -709,44 +718,26 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
                     "409": {
                         "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -781,8 +772,26 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -865,8 +874,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position position found.",
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -883,8 +892,8 @@
                             }
                         }
                     },
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
+                    "404": {
+                        "description": "No debt position position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -979,26 +988,8 @@
                             }
                         }
                     },
-                    "409": {
-                        "description": "Conflict: debt position is not in invalidable state.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position found.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1033,8 +1024,26 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "409": {
+                        "description": "Conflict: debt position is not in invalidable state.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1100,17 +1109,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "409": {
                         "description": "Conflict: debt position is not in publishable state.",
                         "headers": {
@@ -1129,8 +1127,19 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1165,8 +1174,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1232,35 +1241,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No payment option found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Obtained payment option details.",
                         "headers": {
@@ -1279,8 +1259,37 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1367,44 +1376,8 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable payment option.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No payment option found.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1439,8 +1412,44 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "422": {
+                        "description": "Unprocessable payment option.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1516,19 +1525,8 @@
                     "required": true
                 },
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
+                    "422": {
+                        "description": "Unprocessable: not in payable state.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1541,6 +1539,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -1563,26 +1572,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No payment option found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable: not in payable state.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1617,8 +1608,26 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1693,17 +1702,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Request reported.",
                         "headers": {
@@ -1718,42 +1716,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: existing related payment found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1776,8 +1738,55 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Service unavailable.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -2643,2461 +2652,4 @@
             }
         }
     }
-  ],
-  "tags": [
-    {
-      "name": "Debt Positions API"
-    },
-    {
-      "name": "Configurations API"
-    },
-    {
-      "name": "Debt Position Actions API"
-    },
-    {
-      "name": "Payments API"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations": {
-      "get": {
-        "tags": [
-          "Configurations API"
-        ],
-        "summary": "Return the list of the organizations.",
-        "operationId": "getOrganizations",
-        "parameters": [
-          {
-            "name": "since",
-            "in": "query",
-            "description": "Filter from date (use the format yyyy-MM-dd)",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained organizations to add and delete.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationListModelResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 50
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "COMPANY_NAME",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}": {
-      "get": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "Return the details of a specific payment option.",
-        "operationId": "getOrganizationPaymentOptionByIUV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Obtained payment option details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The Organization paid a payment option.",
-        "operationId": "payPaymentOption",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PayPaymentOptionModel"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request paid.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable: not in payable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization reports a transaction.",
-        "operationId": "reportTransfer",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "transferid",
-            "in": "path",
-            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request reported.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No transfer found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    }
-  },
-  "components": {
-    "schemas": {
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "description": {
-            "type": "string"
-          },
-          "isPartialPayment": {
-            "type": "boolean"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
-          },
-          "fiscalCode": {
-            "type": "string"
-          },
-          "fullName": {
-            "type": "string"
-          },
-          "streetName": {
-            "type": "string"
-          },
-          "civicNumber": {
-            "type": "string"
-          },
-          "postalCode": {
-            "type": "string"
-          },
-          "city": {
-            "type": "string"
-          },
-          "province": {
-            "type": "string"
-          },
-          "region": {
-            "type": "string"
-          },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
-          },
-          "companyName": {
-            "type": "string"
-          },
-          "officeName": {
-            "type": "string"
-          },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
-          },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
-            }
-          }
-        }
-      },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "type": "string",
-            "description": "Document hash"
-          },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
-          },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
-          }
-        }
-      },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
-          },
-          "remittanceInformation": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with postalIban and stamp",
-            "example": "IT0000000000000000000000000"
-          },
-          "postalIban": {
-            "type": "string",
-            "description": "mutual exclusive with iban and stamp",
-            "example": "IT0000000000000000000000000"
-          },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
-          }
-        }
-      },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
-          },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
-          },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
-          }
-        }
-      },
-      "PaymentsTransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "idTransfer": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "remittanceInformation": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "iban": {
-            "type": "string"
-          },
-          "postalIban": {
-            "type": "string"
-          },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
-          },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "PayPaymentOptionModel": {
-        "required": [
-          "idReceipt",
-          "pspCompany"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentMethod": {
-            "type": "string"
-          },
-          "pspCompany": {
-            "type": "string"
-          },
-          "idReceipt": {
-            "type": "string"
-          },
-          "fee": {
-            "type": "string"
-          }
-        }
-      },
-      "PaymentsModelResponse": {
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
-          },
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "description": {
-            "type": "string"
-          },
-          "isPartialPayment": {
-            "type": "boolean"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentMethod": {
-            "type": "string"
-          },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "pspCompany": {
-            "type": "string"
-          },
-          "idReceipt": {
-            "type": "string"
-          },
-          "idFlowReporting": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
-          },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-            }
-          }
-        }
-      },
-      "OrganizationListModelResponse": {
-        "type": "object",
-        "properties": {
-          "add": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OrganizationModelResponse"
-            }
-          },
-          "delete": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OrganizationModelResponse"
-            }
-          }
-        }
-      },
-      "OrganizationModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
-          }
-        }
-      },
-      "PaymentsWithDebtorInfoModelResponse": {
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
-          },
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "description": {
-            "type": "string"
-          },
-          "isPartialPayment": {
-            "type": "boolean"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentMethod": {
-            "type": "string"
-          },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "pspCompany": {
-            "type": "string"
-          },
-          "idReceipt": {
-            "type": "string"
-          },
-          "idFlowReporting": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
-          },
-          "fiscalCode": {
-            "type": "string"
-          },
-          "fullName": {
-            "type": "string"
-          },
-          "streetName": {
-            "type": "string"
-          },
-          "civicNumber": {
-            "type": "string"
-          },
-          "postalCode": {
-            "type": "string"
-          },
-          "city": {
-            "type": "string"
-          },
-          "province": {
-            "type": "string"
-          },
-          "region": {
-            "type": "string"
-          },
-          "country": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          },
-          "companyName": {
-            "type": "string"
-          },
-          "officeName": {
-            "type": "string"
-          },
-          "debtPositionStatus": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
-          },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-            }
-          }
-        }
-      },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
-          },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
-          },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
-          },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
-          }
-        }
-      },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
-          },
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "description": {
-            "type": "string"
-          },
-          "isPartialPayment": {
-            "type": "boolean"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentMethod": {
-            "type": "string"
-          },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "pspCompany": {
-            "type": "string"
-          },
-          "idReceipt": {
-            "type": "string"
-          },
-          "idFlowReporting": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
-          },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
-          },
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
-          },
-          "companyName": {
-            "type": "string"
-          },
-          "officeName": {
-            "type": "string"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
-          },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-            }
-          },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
-          }
-        }
-      },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
-          },
-          "idTransfer": {
-            "type": "string"
-          },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "remittanceInformation": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "iban": {
-            "type": "string"
-          },
-          "postalIban": {
-            "type": "string"
-          },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
-          },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
-          },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "environment": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
-      },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
-      }
-    }
-  }
 }

--- a/gpd/pom.xml
+++ b/gpd/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>it.gov.pagopa.debtposition</groupId>
     <artifactId>gpd</artifactId>
-    <version>0.4.6-1</version>
+    <version>0.4.6-2</version>
     <name>Gestione Posizioni Debitorie</name>
     <description>Progetto Gestione Posizioni Debitorie</description>
     <properties>

--- a/gpd/pom.xml
+++ b/gpd/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>it.gov.pagopa.debtposition</groupId>
     <artifactId>gpd</artifactId>
-    <version>0.4.6</version>
+    <version>0.4.6-1</version>
     <name>Gestione Posizioni Debitorie</name>
     <description>Progetto Gestione Posizioni Debitorie</description>
     <properties>

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
@@ -14,7 +14,6 @@ import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionModelResp
 import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionWithDebtorInfoModelResponse;
 import it.gov.pagopa.debtposition.model.payments.response.TransferModelResponse;
 import it.gov.pagopa.debtposition.model.pd.NotificationFeeUpdateModel;
-import it.gov.pagopa.debtposition.model.pd.PaymentPositionModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
@@ -13,13 +13,11 @@ import it.gov.pagopa.debtposition.model.payments.PaymentOptionModel;
 import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionModelResponse;
 import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionWithDebtorInfoModelResponse;
 import it.gov.pagopa.debtposition.model.payments.response.TransferModelResponse;
+import it.gov.pagopa.debtposition.model.pd.NotificationFeeUpdateModel;
+import it.gov.pagopa.debtposition.model.pd.PaymentPositionModel;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -78,5 +76,22 @@ public interface IPaymentsController {
             @PathVariable("iuv") String iuv,
             @Parameter(description = "Transaction identifier. Alphanumeric code that identifies the specific transaction", required = true)
             @PathVariable("transferid") String transferId);
+
+    @Operation(summary = "The organization updates the notification fee of a payment option.", security = {@SecurityRequirement(name = "ApiKey"), @SecurityRequirement(name = "Authorization")}, operationId = "updateNotificationFee")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request updated."),
+            @ApiResponse(responseCode = "400", description = "Malformed request.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "401", description = "Wrong or missing function key.", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "404", description = "No payment option found.", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "422", description = "Unprocessable payment option.", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "500", description = "Service unavailable.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))})
+    @PutMapping(value = "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationFee",
+            produces = {"application/json"})
+    ResponseEntity<PaymentOptionModelResponse> updateNotificationFee(
+            @Parameter(description = "Organization fiscal code, the fiscal code of the Organization.", required = true)
+            @PathVariable("organizationfiscalcode") String organizationFiscalCode,
+            @Parameter(description = "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount", required = true)
+            @PathVariable("iuv") String iuv,
+            @Valid @RequestBody NotificationFeeUpdateModel notificationFeeUpdateModel);
 
 }

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/IPaymentsController.java
@@ -85,7 +85,7 @@ public interface IPaymentsController {
             @ApiResponse(responseCode = "404", description = "No payment option found.", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "422", description = "Unprocessable payment option.", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "500", description = "Service unavailable.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))})
-    @PutMapping(value = "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationFee",
+    @PutMapping(value = "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationfee",
             produces = {"application/json"})
     ResponseEntity<PaymentOptionModelResponse> updateNotificationFee(
             @Parameter(description = "Organization fiscal code, the fiscal code of the Organization.", required = true)

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/impl/PaymentsController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/payments/api/impl/PaymentsController.java
@@ -9,6 +9,8 @@ import it.gov.pagopa.debtposition.model.payments.PaymentOptionModel;
 import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionModelResponse;
 import it.gov.pagopa.debtposition.model.payments.response.PaymentOptionWithDebtorInfoModelResponse;
 import it.gov.pagopa.debtposition.model.payments.response.TransferModelResponse;
+import it.gov.pagopa.debtposition.model.pd.NotificationFeeUpdateModel;
+import it.gov.pagopa.debtposition.model.pd.PaymentPositionModel;
 import it.gov.pagopa.debtposition.service.payments.PaymentsService;
 import it.gov.pagopa.debtposition.util.ObjectMapperUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +71,18 @@ public class PaymentsController implements IPaymentsController {
             return new ResponseEntity<>(ObjectMapperUtils.map(reportedTransfer, TransferModelResponse.class), HttpStatus.OK);
         }
         throw new AppException(AppError.TRANSFER_REPORTING_FAILED, organizationFiscalCode, iuv, transferId);
+    }
+
+    @Override
+    public ResponseEntity<PaymentOptionModelResponse> updateNotificationFee(String organizationFiscalCode, String iuv,
+                                                                      NotificationFeeUpdateModel notificationFeeUpdateModel) {
+        Long notificationFee = notificationFeeUpdateModel.getNotificationFee();
+        log.info(String.format(LOG_BASE_HEADER_INFO, "PUT", "updateNotificationFee", String.format(LOG_BASE_PARAMS_DETAIL, organizationFiscalCode, iuv) + "; notificationFee=" + notificationFee));
+        PaymentOption updatedPaymentOption = paymentsService.updateNotificationFee(organizationFiscalCode, iuv, notificationFee);
+        if (updatedPaymentOption != null) {
+            return new ResponseEntity<>(ObjectMapperUtils.map(updatedPaymentOption, PaymentOptionModelResponse.class), HttpStatus.OK);
+        }
+        throw new AppException(AppError.PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_FAILED, organizationFiscalCode, iuv);
     }
 
 }

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/pd/crud/api/IDebtPositionController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/pd/crud/api/IDebtPositionController.java
@@ -124,5 +124,6 @@ public interface IDebtPositionController {
             @PathVariable("organizationfiscalcode") String organizationFiscalCode,
             @Parameter(description = "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.", required = true)
             @PathVariable("iupd") String iupd,
-            @Valid @RequestBody PaymentPositionModel paymentPositionModel);
+            @Valid @RequestBody PaymentPositionModel paymentPositionModel,
+            @RequestParam(required = false, defaultValue = "false") boolean toPublish);
 }

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/controller/pd/crud/api/impl/DebtPositionController.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/controller/pd/crud/api/impl/DebtPositionController.java
@@ -123,7 +123,8 @@ public class DebtPositionController implements IDebtPositionController {
 
     @Override
     public ResponseEntity<PaymentPositionModel> updateDebtPosition(String organizationFiscalCode, String iupd,
-                                                                   @Valid PaymentPositionModel paymentPositionModel) {
+                                                                   @Valid PaymentPositionModel paymentPositionModel,
+                                                                   boolean toPublish) {
         final String IUPD_VALIDATION_ERROR = "IUPD mistmatch error: path variable IUPD [%s] and request body IUPD [%s] must be the same";
 
         log.info(String.format(LOG_BASE_HEADER_INFO, "PUT", "updateDebtPosition", String.format(LOG_BASE_PARAMS_DETAIL, organizationFiscalCode, iupd)));
@@ -135,7 +136,7 @@ public class DebtPositionController implements IDebtPositionController {
             throw new AppException(AppError.DEBT_POSITION_REQUEST_DATA_ERROR, String.format(IUPD_VALIDATION_ERROR, iupd, paymentPositionModel.getIupd()));
         }
 
-        PaymentPosition updatedDebtPos = paymentPositionService.update(paymentPositionModel, organizationFiscalCode);
+        PaymentPosition updatedDebtPos = paymentPositionService.update(paymentPositionModel, organizationFiscalCode, toPublish);
 
         if (null != updatedDebtPos) {
             return new ResponseEntity<>(modelMapper.map(updatedDebtPos, PaymentPositionModel.class), HttpStatus.OK);

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/entity/PaymentOption.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/entity/PaymentOption.java
@@ -81,6 +81,9 @@ public class PaymentOption implements Serializable {
 
     private long fee;
 
+    @Column(name = "notification_fee")
+    private long notificationFee;
+
     @Column(name = "psp_company")
     private String pspCompany;
 

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
@@ -21,14 +21,17 @@ public enum AppError {
     DEBT_POSITION_INVALIDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The debt position invalidate is failed", "Invalidate failed for the debt position with Organization Fiscal Code %s and IUPD %s"),
     DEBT_POSITION_NOT_INVALIDABLE(HttpStatus.CONFLICT, "Existing related payment found or not in invalidable state", "A payment transaction has already been carried out or, the debt position with Organization Fiscal Code %s and IUPD %s, is not in invalidable state"),
     DEBT_POSITION_NOT_RECOVERABLE(HttpStatus.BAD_REQUEST, "The debt positions cannot be recovered", "Debt positions cannot be recovered. Verify that due_date_to >= due_date_from and that the interval between the two dates not exceed the maximum number of days allowed [due_date_from= %s, due_date_to= %s, days_between_from_to= %s, max_days_interval= %s]"),
+    ORGANIZATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Not found the organization", "Not found an organization for the Organization Fiscal Code %s"),
     PAYMENT_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Not found the payment option", "Not found a payment option for Organization Fiscal Code %s and IUV %s"),
     PAYMENT_OPTION_NOT_PAYABLE(HttpStatus.UNPROCESSABLE_ENTITY, "Not in payable state", "The payment option with Organization Fiscal Code %s and IUV %s is not in payable state"),
     PAYMENT_OPTION_ALREADY_PAID(HttpStatus.CONFLICT, "Existing related payment found", "A payment transaction has already been carried out for the Organization Fiscal Code %s and IUV %s"),
+    PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The update of the notification fee for the payment option is failed", "Notification fee update failed for the payment option with Organization Fiscal Code %s and IUV %s"),
+    PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_NOT_UPDATABLE(HttpStatus.UNPROCESSABLE_ENTITY, "Not in unpaid state for notification fee update", "The payment option with Organization Fiscal Code %s and IUV %s is not in unpaid state and the notification fee cannot be updated."),
+    PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_TRANSFER_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "No valid transfer found for notification fee update", "No transfer found for payment option with IUV %s related to Organization Fiscal Code %s"),
     PAYMENT_OPTION_PAY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The pay call for a payment option is failed", "Payment failed for the payment option with Organization Fiscal Code %s and IUV %s"),
     TRANSFER_NOT_FOUND(HttpStatus.NOT_FOUND, "Not found the transfer", "Not found a transfer for Organization Fiscal Code %s, IUV %s and TxID %s"),
     TRANSFER_REPORTING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The reporting for the transfer is failed", "Reporting failed for the transfer with Organization Fiscal Code %s, IUV %s and TxID %s"),
     TRANSFER_NOT_ACCOUNTABLE(HttpStatus.CONFLICT, "transfer is not in accountable state", "The transfer option with Organization Fiscal Code %s, IUV %s and TxID %s is not in payable state"),
-    ORGANIZATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Not found the organization", "Not found an organization for the Organization Fiscal Code %s"),
     UNKNOWN(null, null, null);
 
 

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
@@ -28,6 +28,7 @@ public class ConvertPOEntityToPOWithDebtor implements Converter<PaymentOption, P
         destination.setReportingDate(source.getReportingDate());
         destination.setPaymentMethod(source.getPaymentMethod());
         destination.setFee(source.getFee());
+        destination.setNotificationFee(source.getNotificationFee());
         destination.setPspCompany(source.getPspCompany());
         destination.setIdReceipt(source.getIdReceipt());
         destination.setIdFlowReporting(source.getIdFlowReporting());

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPPModelToPPEntityForUpdate.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPPModelToPPEntityForUpdate.java
@@ -58,6 +58,7 @@ public class ConvertPPModelToPPEntityForUpdate implements Converter<PaymentPosit
         po.setIsPartialPayment(pom.getIsPartialPayment());
         po.setIuv(pom.getIuv());
         po.setRetentionDate(pom.getRetentionDate());
+        po.setNotificationFee(pom.getNotificationFee());
 
         List<TransferModel> transfers = pom.getTransfer();
         if (null != transfers && !transfers.isEmpty()) {

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionModelResponse.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionModelResponse.java
@@ -33,6 +33,7 @@ public class PaymentOptionModelResponse implements Serializable {
     private LocalDateTime insertedDate;
     private String paymentMethod;
     private long fee;
+    private long notificationFee;
     private String pspCompany;
     private String idReceipt;
     private String idFlowReporting;

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
@@ -34,6 +34,7 @@ public class PaymentOptionWithDebtorInfoModelResponse implements Serializable {
     private LocalDateTime insertedDate;
     private String paymentMethod;
     private long fee;
+    private long notificationFee;
     private String pspCompany;
     private String idReceipt;
     private String idFlowReporting;

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/NotificationFeeUpdateModel.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/NotificationFeeUpdateModel.java
@@ -1,0 +1,17 @@
+package it.gov.pagopa.debtposition.model.pd;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+public class NotificationFeeUpdateModel  implements Serializable {
+
+    @NotNull(message = "Notification fee is required")
+    @PositiveOrZero(message = "Notification fee must be greater or equals to zero")
+    private Long notificationFee;
+}

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/PaymentOptionModel.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/PaymentOptionModel.java
@@ -1,11 +1,16 @@
 package it.gov.pagopa.debtposition.model.pd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -31,6 +36,10 @@ public class PaymentOptionModel implements Serializable {
     private LocalDateTime dueDate;
     private LocalDateTime retentionDate;
     private long fee;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private long notificationFee;
 
     @Valid
     private List<TransferModel> transfer = new ArrayList<>();

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/response/PaymentOptionModelResponse.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/response/PaymentOptionModelResponse.java
@@ -31,6 +31,7 @@ public class PaymentOptionModelResponse implements Serializable {
     private LocalDateTime insertedDate;
     private String paymentMethod;
     private long fee;
+    private long notificationFee;
     private String pspCompany;
     private String idReceipt;
     private String idFlowReporting;

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/service/payments/PaymentsService.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/service/payments/PaymentsService.java
@@ -98,9 +98,10 @@ public class PaymentsService {
         if (!PaymentOptionStatus.PO_UNPAID.equals(paymentOption.getStatus())) {
             throw new AppException(AppError.PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_NOT_UPDATABLE, organizationFiscalCode, iuv);
         }
-        //
-        Collection<Transfer> transfers = paymentOption.getTransfer();
+        // Get the first valid transfer to add the fee
+        List<Transfer> transfers = paymentOption.getTransfer();
         Transfer validTransfer = transfers.stream()
+                .sorted(Comparator.comparing(Transfer::getIdTransfer))
                 .filter(transfer -> organizationFiscalCode.equals(transfer.getOrganizationFiscalCode()))
                 .findFirst()
                 .orElseThrow(() -> new AppException(AppError.PAYMENT_OPTION_NOTIFICATION_FEE_UPDATE_TRANSFER_NOT_FOUND, paymentOption.getIuv(), organizationFiscalCode));

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -160,7 +160,7 @@ public class PaymentPositionCRUDService {
 
 
     @Transactional
-    public PaymentPosition update(@NotNull @Valid PaymentPositionModel paymentPositionModel, @NotBlank String organizationFiscalCode) {
+    public PaymentPosition update(@NotNull @Valid PaymentPositionModel paymentPositionModel, @NotBlank String organizationFiscalCode, boolean toPublish) {
 
         final String ERROR_UPDATE_LOG_MSG = "Error during debt position update: %s";
 
@@ -182,7 +182,7 @@ public class PaymentPositionCRUDService {
             paymentPositionRepository.flush();
             // the version is increased at each change
             ppToUpdate.setVersion(ppToUpdate.getVersion()+1);
-            return this.create(ppToUpdate, organizationFiscalCode, false);
+            return this.create(ppToUpdate, organizationFiscalCode, toPublish);
         	
         } catch (ValidationException e) {
             throw new AppException(AppError.DEBT_POSITION_REQUEST_DATA_ERROR, e.getMessage());

--- a/gpd/src/main/resources/db/migration/V007__ALTER_NOTIFICATIONFEE.sql
+++ b/gpd/src/main/resources/db/migration/V007__ALTER_NOTIFICATIONFEE.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_option ADD COLUMN notification_fee int8 NOT NULL DEFAULT 0;

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.debtposition.controller;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.RequestEntity.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -9,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import it.gov.pagopa.debtposition.dto.PaymentOptionDTO;
 import it.gov.pagopa.debtposition.dto.PaymentPositionDTO;
+import it.gov.pagopa.debtposition.dto.TransferDTO;
+import it.gov.pagopa.debtposition.model.pd.NotificationFeeUpdateModel;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import it.gov.pagopa.debtposition.DebtPositionApplication;
@@ -854,7 +858,171 @@ class PaymentsControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
 		
 	}
-	
+
+
+
+
+	/**
+	 *  UPDATE PAYMENT OPTION'S NOTIFICATION FEE
+	 */
+
+	@Test
+	void updateNotificationFee_200() throws Exception {
+
+		PaymentPositionDTO paymentPositionDTO = DebtPositionMock.paymentPositionForNotificationUpdateMock1();
+		PaymentOptionDTO paymentOptionDTO = paymentPositionDTO.getPaymentOption().get(0);
+		TransferDTO transferDTO = paymentOptionDTO.getTransfer().get(0);
+		NotificationFeeUpdateModel notificationFeeUpdateModel = DebtPositionMock.createNotificationFeeMock(150L);
+
+		// creo una posizione debitoria e recupero la payment option associata
+		mvc.perform(post("/organizations/PO200_notificationfee_12345678901/debtpositions")
+						.content(TestUtil.toJson(paymentPositionDTO))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// leggo il valore della notification fee per accertarmi che non venga inserita anche se passata in input
+		mvc.perform(get("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1")
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.notificationFee")
+						.value(0L));
+
+		// aggiorno il valore della notification fee
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+				.content(TestUtil.toJson(notificationFeeUpdateModel))
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.notificationFee")
+						.value(notificationFeeUpdateModel.getNotificationFee()))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.amount")
+						.value(paymentOptionDTO.getAmount() + notificationFeeUpdateModel.getNotificationFee()))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[0].amount")
+						.value(transferDTO.getAmount() + notificationFeeUpdateModel.getNotificationFee()));
+
+		// leggo nuovamente la payment option per capire se gli amount sono stati modificati correttamente
+		mvc.perform(get("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1")
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.notificationFee")
+						.value(notificationFeeUpdateModel.getNotificationFee()))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.amount")
+						.value(paymentOptionDTO.getAmount() + notificationFeeUpdateModel.getNotificationFee()));
+
+		// aggiorno il valore della notification fee, reimpostandolo a zero ed aspettandomi di ritornare al valore di partenza
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+						.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(0L)))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(MockMvcResultMatchers.jsonPath("$.notificationFee")
+						.value(0L))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.amount")
+						.value(paymentOptionDTO.getAmount()))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[0].amount")
+						.value(transferDTO.getAmount()));
+
+		// leggo nuovamente la payment option per capire se gli amount sono stati modificati correttamente
+		mvc.perform(get("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1")
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.notificationFee")
+						.value(0L))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.amount")
+						.value(paymentOptionDTO.getAmount()));
+	}
+
+	@Test
+	void updateNotificationFee_negativeNotificationFee_400() throws Exception {
+		// creo una posizione debitoria e recupero la payment option associata
+		mvc.perform(post("/organizations/PO400_notificationfee_negative_12345678901/debtpositions")
+						.content(TestUtil.toJson(DebtPositionMock.getMock1())).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// passo una richiesta errata, con notification fee negativo
+		String url = "/organizations/PO400_notificationfee_negative_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		mvc.perform(MockMvcRequestBuilders.put(url)
+				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(-150L)))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void updateNotificationFee_nullNotificationFee_400() throws Exception {
+		// creo una posizione debitoria e recupero la payment option associata
+		mvc.perform(post("/organizations/PO400_notificationfee_null_12345678901/debtpositions")
+						.content(TestUtil.toJson(DebtPositionMock.getMock1())).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// passo una richiesta errata, con notification fee nullo
+		String url = "/organizations/PO400_notificationfee_null_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		mvc.perform(MockMvcRequestBuilders.put(url)
+				.content(TestUtil.toJson(new NotificationFeeUpdateModel()))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void updateNotificationFee_404() throws Exception {
+		String url = "/organizations/PO404_notificationfee_12345678901/paymentoptions/123456IUVNOTEXIST/notificationFee";
+		mvc.perform(MockMvcRequestBuilders.put(url)
+				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
+	}
+
+	@Test
+	void updateNotificationFee_paymentOptionAlreadyPaid_422() throws Exception {
+		// creo una posizione debitoria (senza 'validity date' impostata)
+		mvc.perform(post("/organizations/PO422_notificationfee_paid_12345678901/debtpositions")
+						.content(TestUtil.toJson(DebtPositionMock.getMock1())).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// porto in pubblicata/validata lo stato della posizione debitoria
+		mvc.perform(post("/organizations/PO422_notificationfee_paid_12345678901/debtpositions/12345678901IUPDMOCK1/publish")
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+
+		// effettuo la notifica di pagamento e verifico lo stato in paid
+		mvc.perform(post("/organizations/PO422_notificationfee_paid_12345678901/paymentoptions/123456IUVMOCK1/pay")
+						.content(TestUtil.toJson(DebtPositionMock.getPayPOMock1()))
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.iuv").value("123456IUVMOCK1"))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.status")
+						.value(PaymentOptionStatus.PO_PAID.toString()));
+
+		// recupero l'intera posizione debitoria e verifico lo stato in paid
+		mvc.perform(get("/organizations/PO422_notificationfee_paid_12345678901/debtpositions/12345678901IUPDMOCK1")
+						.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.status")
+						.value(DebtPositionStatus.PAID.toString()));
+
+		// effettuo la chiamata ma non posso continuare perche la PD è stata gia pagata
+		String url = "/organizations/PO422_notificationfee_paid_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		mvc.perform(MockMvcRequestBuilders.put(url)
+				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isUnprocessableEntity());
+	}
+
+	@Test
+	void updateNotificationFee_noValidTransfer_422() throws Exception {
+
+		PaymentPositionDTO paymentPositionDTO = DebtPositionMock.paymentPositionForNotificationUpdateMock1();
+
+		// creo una posizione debitoria e recupero la payment option associata
+		mvc.perform(post("/organizations/PO422_notificationfee_invalidtransfer_12345678901/debtpositions")
+						.content(TestUtil.toJson(paymentPositionDTO))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// aggiorno il nome dell'ufficio per la posizione debitoria
+		paymentPositionDTO.getPaymentOption().get(0).getTransfer().get(0).setOrganizationFiscalCode("hfdkjshfkdha");
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO422_notificationfee_invalidtransfer_12345678901/debtpositions/12345678901IUPDMOCK1")
+				.content(TestUtil.toJson(paymentPositionDTO))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
+
+		// effettuo la chiamata ma non posso continuare perche non esiste un transfer correlata all'EC in input
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO422_notificationfee_invalidtransfer_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
+				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isUnprocessableEntity());
+	}
+
 	/**
 	 *  VALIDATION TEST - unexpected case
 	 */

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
@@ -888,7 +888,7 @@ class PaymentsControllerTest {
 						.value(0L));
 
 		// aggiorno il valore della notification fee
-		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationfee")
 				.content(TestUtil.toJson(notificationFeeUpdateModel))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -909,7 +909,7 @@ class PaymentsControllerTest {
 						.value(paymentOptionDTO.getAmount() + notificationFeeUpdateModel.getNotificationFee()));
 
 		// aggiorno il valore della notification fee, reimpostandolo a zero ed aspettandomi di ritornare al valore di partenza
-		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO200_notificationfee_12345678901/paymentoptions/123456IUVMOCK1/notificationfee")
 						.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(0L)))
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -938,7 +938,7 @@ class PaymentsControllerTest {
 				.andExpect(status().isCreated());
 
 		// passo una richiesta errata, con notification fee negativo
-		String url = "/organizations/PO400_notificationfee_negative_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		String url = "/organizations/PO400_notificationfee_negative_12345678901/paymentoptions/123456IUVMOCK1/notificationfee";
 		mvc.perform(MockMvcRequestBuilders.put(url)
 				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(-150L)))
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
@@ -952,7 +952,7 @@ class PaymentsControllerTest {
 				.andExpect(status().isCreated());
 
 		// passo una richiesta errata, con notification fee nullo
-		String url = "/organizations/PO400_notificationfee_null_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		String url = "/organizations/PO400_notificationfee_null_12345678901/paymentoptions/123456IUVMOCK1/notificationfee";
 		mvc.perform(MockMvcRequestBuilders.put(url)
 				.content(TestUtil.toJson(new NotificationFeeUpdateModel()))
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
@@ -960,7 +960,7 @@ class PaymentsControllerTest {
 
 	@Test
 	void updateNotificationFee_404() throws Exception {
-		String url = "/organizations/PO404_notificationfee_12345678901/paymentoptions/123456IUVNOTEXIST/notificationFee";
+		String url = "/organizations/PO404_notificationfee_12345678901/paymentoptions/123456IUVNOTEXIST/notificationfee";
 		mvc.perform(MockMvcRequestBuilders.put(url)
 				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound());
@@ -994,7 +994,7 @@ class PaymentsControllerTest {
 						.value(DebtPositionStatus.PAID.toString()));
 
 		// effettuo la chiamata ma non posso continuare perche la PD è stata gia pagata
-		String url = "/organizations/PO422_notificationfee_paid_12345678901/paymentoptions/123456IUVMOCK1/notificationFee";
+		String url = "/organizations/PO422_notificationfee_paid_12345678901/paymentoptions/123456IUVMOCK1/notificationfee";
 		mvc.perform(MockMvcRequestBuilders.put(url)
 				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isUnprocessableEntity());
@@ -1018,7 +1018,7 @@ class PaymentsControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
 
 		// effettuo la chiamata ma non posso continuare perche non esiste un transfer correlata all'EC in input
-		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO422_notificationfee_invalidtransfer_12345678901/paymentoptions/123456IUVMOCK1/notificationFee")
+		mvc.perform(MockMvcRequestBuilders.put("/organizations/PO422_notificationfee_invalidtransfer_12345678901/paymentoptions/123456IUVMOCK1/notificationfee")
 				.content(TestUtil.toJson(DebtPositionMock.createNotificationFeeMock(150L)))
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(status().isUnprocessableEntity());
 	}

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/dto/PaymentOptionDTO.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/dto/PaymentOptionDTO.java
@@ -30,6 +30,7 @@ public class PaymentOptionDTO implements Serializable {
     private LocalDateTime reportingDate;
     private String paymentMethod;
     private long fee;
+    private long notificationFee; // needed for testing if ignored in unmarshalling
     private String pspCompany;
     private String idReceipt;
     private String idFlowReporting;

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/mock/DebtPositionMock.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/mock/DebtPositionMock.java
@@ -10,7 +10,7 @@ import it.gov.pagopa.debtposition.dto.TransferDTO;
 import it.gov.pagopa.debtposition.model.enumeration.DebtPositionStatus;
 import it.gov.pagopa.debtposition.model.enumeration.PaymentOptionStatus;
 import it.gov.pagopa.debtposition.model.enumeration.Type;
-
+import it.gov.pagopa.debtposition.model.pd.NotificationFeeUpdateModel;
 
 
 public class DebtPositionMock {
@@ -926,4 +926,15 @@ public class DebtPositionMock {
 		return tMock;
 	}
 
+	public static PaymentPositionDTO paymentPositionForNotificationUpdateMock1() {
+		PaymentPositionDTO mock = createPaymentPositionMock1();
+		mock.getPaymentOption().get(0).setNotificationFee(300L);
+		return mock;
+	}
+
+	public static NotificationFeeUpdateModel createNotificationFeeMock(long notificationFee) {
+		NotificationFeeUpdateModel mock = new NotificationFeeUpdateModel();
+		mock.setNotificationFee(notificationFee);
+		return mock;
+	}
 }

--- a/integration-test/run_integration_test.sh
+++ b/integration-test/run_integration_test.sh
@@ -6,8 +6,8 @@ docker stop node-container || true
 docker rm node-container || true
 
 # please see https://github.com/andrea-deri/prebuilt-img-yarn-base for yarn-testing-base image content
-docker pull ${CONTAINER_REGISTRY}/yarn-testing-base:latest
-docker run -dit --name ${containerName} ${CONTAINER_REGISTRY}/yarn-testing-base:latest
+docker pull ${CONTAINER_NAMESPACE}/yarn-testing-base:latest
+docker run -dit --name ${containerName} ${CONTAINER_NAMESPACE}/yarn-testing-base:latest
 
 # run integration tests with yarn
 docker cp -a ./src/. ${containerName}:/test

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>it.gov.pagopa.debtposition</groupId>
             <artifactId>gpd</artifactId>
-	<version>0.4.6-1</version>
+	<version>0.4.6-2</version>
         </dependency>
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>it.gov.pagopa.debtposition</groupId>
             <artifactId>gpd</artifactId>
-	<version>0.4.6</version>
+	<version>0.4.6-1</version>
         </dependency>
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>


### PR DESCRIPTION
With this PR a new feature was added. This new feature is a new API that permits to update the value of the fee related to payment position notification from PN. When the notification fee will be updated, the amount of related transfer and of payment option will be updated in order to also include the needed fee. 
For doing so, it was added a new column that will store the value of the notification fee related to the payment option and the related model field is added. Also, it was added a new model (to be passed as request body for the new API) that contains information about the fee to be updated.

##### Notes
The integration and performance tests from [this task](https://pagopa.atlassian.net/browse/PAGOPA-943) are included in this PR.

#### List of Changes
 - Added new API for update the notification fee value
 - Updated JUnit tests
 - Added new column on `payment_option` table in order to include the notification fee value
 - Updated integration tests including the new API
 - Updated performance tests including the new API

#### Motivation and Context
This changes are needed in order to permits to Piattaforme Notifiche to define a fee on a payment option related to the notification service.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.