### PR TITLE
[PAGOPA-975] fix: wrong handling of organization fiscal code in transfers

### DIFF
--- a/gpd/integration-test/src/step_definitions/support/utility/request_builders.js
+++ b/gpd/integration-test/src/step_definitions/support/utility/request_builders.js
@@ -21,6 +21,7 @@ function buildDebtPositionDynamicData(gpdSessionBundle, iupdIn) {
         idempotency: `60000000001_${makeidNumber(6)}${makeidMix(4)}`,
         applicationDate: buildStringFromDate(addDays(0)),
         transferDate: buildStringFromDate(addDays(1)),
+        transferOtherCIFiscalCode: "01020304059"
     };
 }
 
@@ -61,6 +62,7 @@ function buildCreateDebtPositionRequest(debtPosition, payer) {
                     },
                     {
                         idTransfer: debtPosition.transferId2,
+                        organizationFiscalCode: transferOtherCIFiscalCode,
                         amount: (debtPosition.amount * 100 / 3) * 2,
                         remittanceInformation: "Rata 2",
                         category: "9/0101108TS/",

--- a/gpd/openapi/openapi.json
+++ b/gpd/openapi/openapi.json
@@ -4,11 +4,11 @@
         "title": "PagoPA API Debt Position",
         "description": "Progetto Gestione Posizioni Debitorie",
         "termsOfService": "https://www.pagopa.gov.it/",
-        "version": "0.4.0-4"
+        "version": "0.4.5"
     },
     "servers": [
         {
-            "url": "http://localhost:8085",
+            "url": "http://localhost:8080",
             "description": "Generated server url"
         }
     ],
@@ -35,13 +35,20 @@
                 "summary": "Return OK if application is started",
                 "operationId": "healthCheck",
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "200": {
+                        "description": "OK.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppInfo"
                                 }
                             }
                         }
@@ -64,8 +71,8 @@
                             }
                         }
                     },
-                    "403": {
-                        "description": "Forbidden.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -75,20 +82,13 @@
                             }
                         }
                     },
-                    "200": {
-                        "description": "OK.",
+                    "403": {
+                        "description": "Forbidden.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AppInfo"
                                 }
                             }
                         }
@@ -134,13 +134,20 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "200": {
+                        "description": "Obtained organizations to add and delete.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
                                 }
                             }
                         }
@@ -163,20 +170,13 @@
                             }
                         }
                     },
-                    "200": {
-                        "description": "Obtained organizations to add and delete.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OrganizationListModelResponse"
                                 }
                             }
                         }
@@ -331,8 +331,8 @@
                     }
                 ],
                 "responses": {
-                    "429": {
-                        "description": "Too many requests.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -340,10 +340,17 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "429": {
+                        "description": "Too many requests.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -371,20 +378,13 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -454,55 +454,8 @@
                     "required": true
                 },
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
                     "500": {
                         "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict: duplicate debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -533,6 +486,53 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PaymentPositionModel"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed request.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict: duplicate debt position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -586,17 +586,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Obtained debt position details.",
                         "headers": {
@@ -647,6 +636,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -716,19 +716,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -745,8 +734,8 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -781,8 +770,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -795,6 +784,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -854,8 +854,44 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "No debt position position found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
                     "409": {
                         "description": "Conflict: existing related payment found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -879,42 +915,6 @@
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Service unavailable.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No debt position position found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -968,8 +968,8 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -977,10 +977,17 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1015,20 +1022,13 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1100,8 +1100,8 @@
                     }
                 ],
                 "responses": {
-                    "409": {
-                        "description": "Conflict: debt position is not in publishable state.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1118,8 +1118,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "404": {
+                        "description": "No debt position found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1127,10 +1127,17 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "409": {
+                        "description": "Conflict: debt position is not in publishable state.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1165,20 +1172,13 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No debt position found.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1232,17 +1232,6 @@
                     }
                 ],
                 "responses": {
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
                     "200": {
                         "description": "Obtained payment option details.",
                         "headers": {
@@ -1275,6 +1264,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -1374,13 +1374,20 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
+                    "500": {
+                        "description": "Service unavailable.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1403,38 +1410,13 @@
                             }
                         }
                     },
-                    "500": {
-                        "description": "Service unavailable.",
+                    "401": {
+                        "description": "Wrong or missing function key.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "No payment option found.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1453,6 +1435,24 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/PaymentsModelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No payment option found.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemJson"
                                 }
                             }
                         }
@@ -1569,19 +1569,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "Wrong or missing function key.",
-                        "headers": {
-                            "X-Request-Id": {
-                                "description": "This header identifies the call",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Malformed request.",
+                    "404": {
+                        "description": "No transfer found.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1616,8 +1605,8 @@
                             }
                         }
                     },
-                    "404": {
-                        "description": "No transfer found.",
+                    "400": {
+                        "description": "Malformed request.",
                         "headers": {
                             "X-Request-Id": {
                                 "description": "This header identifies the call",
@@ -1630,6 +1619,17 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ProblemJson"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Wrong or missing function key.",
+                        "headers": {
+                            "X-Request-Id": {
+                                "description": "This header identifies the call",
+                                "schema": {
+                                    "type": "string"
                                 }
                             }
                         }
@@ -1745,6 +1745,7 @@
                         "type": "string"
                     },
                     "country": {
+                        "pattern": "[A-Z]{2}",
                         "type": "string"
                     },
                     "email": {
@@ -1796,11 +1797,36 @@
                     }
                 }
             },
+            "Stamp": {
+                "required": [
+                    "hashDocument",
+                    "provincialResidence",
+                    "stampType"
+                ],
+                "type": "object",
+                "properties": {
+                    "hashDocument": {
+                        "type": "string",
+                        "description": "Document hash"
+                    },
+                    "stampType": {
+                        "maxLength": 2,
+                        "minLength": 2,
+                        "type": "string",
+                        "description": "The type of the stamp"
+                    },
+                    "provincialResidence": {
+                        "pattern": "[A-Z]{2}",
+                        "type": "string",
+                        "description": "The provincial of the residence",
+                        "example": "RM"
+                    }
+                }
+            },
             "TransferModel": {
                 "required": [
                     "amount",
                     "category",
-                    "iban",
                     "idTransfer",
                     "remittanceInformation"
                 ],
@@ -1820,6 +1846,11 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "organizationFiscalCode": {
+                        "type": "string",
+                        "description": "Fiscal code related to the organization targeted by this transfer.",
+                        "example": "00000000000"
+                    },
                     "remittanceInformation": {
                         "type": "string"
                     },
@@ -1827,10 +1858,17 @@
                         "type": "string"
                     },
                     "iban": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "mutual exclusive with postalIban and stamp",
+                        "example": "IT0000000000000000000000000"
                     },
                     "postalIban": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "mutual exclusive with iban and stamp",
+                        "example": "IT0000000000000000000000000"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
                     }
                 }
             },
@@ -1880,6 +1918,9 @@
                     },
                     "postalIban": {
                         "type": "string"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
                     },
                     "insertedDate": {
                         "type": "string",
@@ -2367,6 +2408,9 @@
                     },
                     "postalIban": {
                         "type": "string"
+                    },
+                    "stamp": {
+                        "$ref": "#/components/schemas/Stamp"
                     },
                     "insertedDate": {
                         "type": "string",

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPPModelToPPEntityForUpdate.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPPModelToPPEntityForUpdate.java
@@ -74,6 +74,7 @@ public class ConvertPPModelToPPEntityForUpdate implements Converter<PaymentPosit
 
         Transfer t = new Transfer();
         t.setAmount(tm.getAmount());
+        t.setOrganizationFiscalCode(tm.getOrganizationFiscalCode());
         t.setCategory(tm.getCategory());
         t.setIban(tm.getIban());
         t.setIdTransfer(tm.getIdTransfer());

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/TransferModel.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/model/pd/TransferModel.java
@@ -20,16 +20,25 @@ public class TransferModel implements Serializable {
     @NotBlank(message = "id transfer is required")
     @Schema(type = "string", allowableValues = {"1", "2", "3", "4", "5"})
     private String idTransfer;
+
     @NotNull(message = "amount is required")
     private Long amount;
+
+    @Schema(description = "Fiscal code related to the organization targeted by this transfer.", example = "00000000000")
+    private String organizationFiscalCode;
+
     @NotBlank(message = "remittance information is required")
     private String remittanceInformation; // causale
+
     @NotBlank(message = "category is required")
     private String category; // taxonomy
+
     @Schema(description = "mutual exclusive with postalIban and stamp", example = "IT0000000000000000000000000")
     private String iban;
+
     @Schema(description = "mutual exclusive with iban and stamp", example = "IT0000000000000000000000000")
     private String postalIban;
+
     @Schema(description = "mutual exclusive with iban and postalIban")
     private Stamp stamp;
 

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -81,10 +81,11 @@ public class PaymentPositionCRUDService {
                 po.setStatus(PaymentOptionStatus.PO_UNPAID);
                 for (Transfer t : po.getTransfer()) {
                     t.setIuv(po.getIuv());
-                    t.setOrganizationFiscalCode(organizationFiscalCode);
+                    t.setOrganizationFiscalCode(Objects.requireNonNullElse(t.getOrganizationFiscalCode(), organizationFiscalCode));
                     t.setInsertedDate(Objects.requireNonNullElse(debtPosition.getInsertedDate(), currentDate));
                     t.setLastUpdatedDate(currentDate);
                     t.setStatus(TransferStatus.T_UNREPORTED);
+
                 }
             }
 

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/DebtPositionControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/DebtPositionControllerTest.java
@@ -68,6 +68,28 @@ class DebtPositionControllerTest {
 	}
 
 	@Test
+	void createDebtPosition_transferToDifferentCI_200() throws Exception {
+
+		PaymentPositionDTO paymentPositionDTO = DebtPositionMock.getMock1();
+		paymentPositionDTO.getPaymentOption().get(0).getTransfer().get(0).setOrganizationFiscalCode("ANOTHERCI123");
+
+		mvc.perform(post("/organizations/12345678901200_transferToDifferentCI/debtpositions")
+						.content(TestUtil.toJson(paymentPositionDTO)).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		// recupero la posizione debitoria e controllo i valori dei fiscal code degli EC
+		String url = "/organizations/12345678901200_transferToDifferentCI/debtpositions/12345678901IUPDMOCK1";
+		mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.organizationFiscalCode")
+						.value("12345678901200_transferToDifferentCI"))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.paymentOption[0].organizationFiscalCode")
+						.value("12345678901200_transferToDifferentCI"))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.paymentOption[0].transfer[0].organizationFiscalCode")
+						.value("ANOTHERCI123"));
+	}
+
+	@Test
 	void createDebtPosition_400() throws Exception {
 		mvc.perform(post("/organizations/400_12345678901/debtpositions")
 				.content(TestUtil.toJson(DebtPositionMock.get400Mock1())).contentType(MediaType.APPLICATION_JSON))

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import it.gov.pagopa.debtposition.dto.PaymentOptionDTO;
+import it.gov.pagopa.debtposition.dto.PaymentPositionDTO;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,26 @@ class PaymentsControllerTest {
 				.value(PaymentOptionStatus.PO_PAID.toString()))
 		.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[*]")
 				.value(Matchers.hasSize(1)));
+	}
+
+	@Test
+	void getPaymentOptionByIUV_transferToDifferentCI_200() throws Exception {
+
+		PaymentPositionDTO paymentPositionDTO = DebtPositionMock.getMock1();
+		paymentPositionDTO.getPaymentOption().get(0).getTransfer().get(0).setOrganizationFiscalCode("ANOTHERCI123");
+
+		// creo una posizione debitoria e recupero la payment option associata
+		mvc.perform(post("/organizations/PO200_transferToDifferentCI_12345678901/debtpositions")
+						.content(TestUtil.toJson(paymentPositionDTO)).contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+
+		String url = "/organizations/PO200_transferToDifferentCI_12345678901/paymentoptions/123456IUVMOCK1";
+		mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.organizationFiscalCode")
+						.value("PO200_transferToDifferentCI_12345678901"))
+				.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[0].organizationFiscalCode")
+						.value("ANOTHERCI123"));
 	}
 
 	@Test

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
@@ -126,15 +126,15 @@ class PaymentsControllerTest {
 		paymentPositionDTO.getPaymentOption().get(0).getTransfer().get(0).setOrganizationFiscalCode("ANOTHERCI123");
 
 		// creo una posizione debitoria e recupero la payment option associata
-		mvc.perform(post("/organizations/PO200_transferToDifferentCI_12345678901/debtpositions")
+		mvc.perform(post("/organizations/PO200_getTransferToDifferentCI_12345678901/debtpositions")
 						.content(TestUtil.toJson(paymentPositionDTO)).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated());
 
-		String url = "/organizations/PO200_transferToDifferentCI_12345678901/paymentoptions/123456IUVMOCK1";
+		String url = "/organizations/PO200_getTransferToDifferentCI_12345678901/paymentoptions/123456IUVMOCK1";
 		mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
 				.andExpect(MockMvcResultMatchers.jsonPath("$.organizationFiscalCode")
-						.value("PO200_transferToDifferentCI_12345678901"))
+						.value("PO200_getTransferToDifferentCI_12345678901"))
 				.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[0].organizationFiscalCode")
 						.value("ANOTHERCI123"));
 	}

--- a/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
+++ b/gpd/src/test/java/it/gov/pagopa/debtposition/controller/PaymentsControllerTest.java
@@ -120,26 +120,6 @@ class PaymentsControllerTest {
 	}
 
 	@Test
-	void getPaymentOptionByIUV_transferToDifferentCI_200() throws Exception {
-
-		PaymentPositionDTO paymentPositionDTO = DebtPositionMock.getMock1();
-		paymentPositionDTO.getPaymentOption().get(0).getTransfer().get(0).setOrganizationFiscalCode("ANOTHERCI123");
-
-		// creo una posizione debitoria e recupero la payment option associata
-		mvc.perform(post("/organizations/PO200_getTransferToDifferentCI_12345678901/debtpositions")
-						.content(TestUtil.toJson(paymentPositionDTO)).contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isCreated());
-
-		String url = "/organizations/PO200_getTransferToDifferentCI_12345678901/paymentoptions/123456IUVMOCK1";
-		mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-				.andExpect(MockMvcResultMatchers.jsonPath("$.organizationFiscalCode")
-						.value("PO200_getTransferToDifferentCI_12345678901"))
-				.andExpect(MockMvcResultMatchers.jsonPath("$.transfer[0].organizationFiscalCode")
-						.value("ANOTHERCI123"));
-	}
-
-	@Test
 	void getPaymentOptionByIUV_404() throws Exception {
 		String url = "/organizations/PO200_12345678901/paymentoptions/123456IUVNOTEXIST";
 		mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound())


### PR DESCRIPTION
With this PR will be resolved a bug on which the `organizationFiscalCode` field in `transfer` object always have the same value of the organization fiscal code passed as path parameter. Now this field can be set manually in that situation where the transfer must be made on another organization, different from the one where the debt position is defined. In order to respect the API backward compatibility in production environment, if no `organizationFiscalCode` value in `transfer` object is set, the one passed as path parameter will be added. 

**Note**: This fix will not includes big changes on integration and load test due to the fact that it will not add much more complex handling and special operations on the existing logic. [This PR](https://github.com/pagopa/pagopa-debt-position/pull/145) will handle more complex calculation on notification fee that must eventually check the transfer's organization fiscal code, so all updates on tests will be made there.

#### List of Changes
 - Added optional set of organization fiscal code in transfer object in create/update

#### Motivation and Context
This changes resolves the bug previously explained and permits more customization on debt position creation.

#### How Has This Been Tested?
 - Tested in local environment

**Note**: Will be fully tested in other environments by the tests made for [this PR](https://github.com/pagopa/pagopa-debt-position/pull/145).

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.