### PR TITLE
[PAGOPA-981] Notification fee sum on debt position amount during update

### DIFF
--- a/gpd/pom.xml
+++ b/gpd/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>it.gov.pagopa.debtposition</groupId>
     <artifactId>gpd</artifactId>
-    <version>0.4.8</version>
+    <version>0.4.8-1</version>
     <name>Gestione Posizioni Debitorie</name>
     <description>Progetto Gestione Posizioni Debitorie</description>
     <properties>

--- a/gpd/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
+++ b/gpd/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
@@ -11,6 +11,7 @@ public enum AppError {
     DEBT_POSITION_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The debt position creation is failed", "Creation failed for the debt position with Organization Fiscal Code %s"),
     DEBT_POSITION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "The debt position update is failed", "Update failed for the debt position with Organization Fiscal Code %s"),
     DEBT_POSITION_UNIQUE_VIOLATION(HttpStatus.CONFLICT, "The debt position violated constraints of uniqueness", "Already exists a debt position for the Organization Fiscal Code %s or one of its payment options is not unique"),
+    DEBT_POSITION_UPDATE_FAILED_NO_TRANSFER_FOR_NOTIFICATION_FEE(HttpStatus.UNPROCESSABLE_ENTITY, "The debt position update is failed", "No valid transfer found to apply the registered notification fee on the debt position with Organization Fiscal Code %s and IUPD %s"),
     DEBT_POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "Not found the debt position", "Not found a debt position for Organization Fiscal Code %s and IUPD %s"),
     DEBT_POSITION_PAYMENT_FOUND(HttpStatus.CONFLICT, "Existing related payment found", "A payment transaction has already been carried out on the debt position with Organization Fiscal Code %s and IUPD %s"),
     DEBT_POSITION_NOT_UPDATABLE(HttpStatus.CONFLICT, "Existing related payment found or not in updatable state", "A payment transaction has already been carried out or, the debt position with Organization Fiscal Code %s and IUPD %s, is not in updatable state"),

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>it.gov.pagopa.debtposition</groupId>
             <artifactId>gpd</artifactId>
-	<version>0.4.8</version>
+	<version>0.4.8-1</version>
         </dependency>
         <dependency>
             <groupId>it.gov.pagopa.reporting</groupId>


### PR DESCRIPTION
With this pull request the functioning of debt position update is fixed from a previous bug. This fix includes the explicit update of the payment option and transfer amount values with the existing notification fee value.
Also, it was added a check on which if a notification fee is set, it is not possible to have only transfers not related to creditor institution different from the debt position one. 

#### List of Changes
 - Resolved bug on payment option amount update
 - Added check on transfers when notification fee is set
 - Updated JUnit tests for evaluate new checks

#### Motivation and Context
This change permits to resolve a well-known bug on debt position update related to amount change.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.