### PR TITLE
chore: Update OpenAPI generator

### DIFF
--- a/openapi/generate_openapi.sh
+++ b/openapi/generate_openapi.sh
@@ -1,3 +1,28 @@
 #!/bin/bash
-curl http://localhost:8080/v3/api-docs/internal > ./openapi_internal.json
-curl http://localhost:8080/v3/api-docs/external > ./openapi_external.json
+
+if [[ "$(pwd)" =~ .*"openapi".* ]]; then
+    cd ..
+fi
+
+if ! $(curl --output /dev/null --silent --head --fail http://localhost:8080/info); then
+  mvn spring-boot:run -Dmaven.test.skip=true -Dspring-boot.run.profiles=h2 &
+fi
+
+# waiting the service
+printf 'Waiting for the service'
+attempt_counter=0
+max_attempts=50
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080/info); do
+    if [ ${attempt_counter} -eq ${max_attempts} ];then
+      echo "Max attempts reached"
+      exit 1
+    fi
+
+    printf '.'
+    attempt_counter=$((attempt_counter+1))
+    sleep 5
+done
+echo 'Service Started'
+
+curl http://localhost:8080/v3/api-docs > ./openapi/openapi_internal.json
+curl http://localhost:8080/v3/api-docs/external > ./openapi/openapi_external.json

--- a/openapi/openapi_external.json
+++ b/openapi/openapi_external.json
@@ -1,1279 +1,1121 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.6.14"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.6.14"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Debt Positions API"
-    },
-    {
-      "name": "Debt Position Actions API"
-    }
-  ],
-  "paths": {
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost:8080",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Debt Positions API"
+  }, {
+    "name" : "Debt Position Actions API"
+  } ],
+  "paths" : {
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "No debt position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "404" : {
+            "description" : "No debt position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Malformed request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "Request updated.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "200": {
-            "description": "Request updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "No debt position position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       }
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 100,
-              "type": "integer",
-              "format": "int32",
-              "default": 50
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "COMPANY_NAME",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 100,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 50
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "COMPANY_NAME",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests."
-          },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
+          "429" : {
+            "description" : "Too many requests."
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "201": {
-            "description": "Request created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "201" : {
+            "description" : "Request created.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       }
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "No debt position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "Request published.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "200" : {
+            "description" : "Request published.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       }
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "No debt position found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "Request published.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "401" : {
+            "description" : "Wrong or missing function key."
+          },
+          "200" : {
+            "description" : "Request published.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden."
+          "401" : {
+            "description" : "Wrong or missing function key."
           },
-          "401": {
-            "description": "Wrong or missing function key."
+          "403" : {
+            "description" : "Forbidden."
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string",
-            "readOnly": true
+  "components" : {
+    "schemas" : {
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string",
+            "readOnly" : true
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "type": "string",
-            "description": "Document hash"
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "type" : "string",
+            "description" : "Document hash"
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with postalIban and stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with postalIban and stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "mutual exclusive with iban and stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with iban and stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
       }
     }
   }

--- a/openapi/openapi_internal.json
+++ b/openapi/openapi_internal.json
@@ -1,1969 +1,2315 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.6.14"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.6.14"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Debt Positions API"
-    },
-    {
-      "name": "Debt Position Actions API"
-    },
-    {
-      "name": "Payments API"
-    }
-  ],
-  "paths": {
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationfee": {
-      "put": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization updates the notification fee of a payment option.",
-        "operationId": "updateNotificationFee",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+  "servers" : [ {
+    "url" : "http://localhost:8080",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Debt Positions API"
+  }, {
+    "name" : "Debt Position Actions API"
+  }, {
+    "name" : "Payments API"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
               }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "422": {
-            "description": "Unprocessable payment option.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "404": {
-            "description": "No payment option found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
-            }
-          },
-          "200": {
-            "description": "Request updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 100,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 50
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "COMPANY_NAME",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
               }
             }
           },
-          "required": true
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
         },
-        "responses": {
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
-    },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization reports a transaction.",
-        "operationId": "reportTransfer",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "transferid",
-            "in": "path",
-            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request reported.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsTransferModelResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No transfer found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
-    },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The Organization paid a payment option.",
-        "operationId": "payPaymentOption",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PayPaymentOptionModel"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "404": {
-            "description": "No payment option found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Request paid.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable: not in payable state.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
-    },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 100,
-              "type": "integer",
-              "format": "int32",
-              "default": 50
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "COMPANY_NAME",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many requests."
-          },
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "400": {
-            "description": "Malformed request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Request created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "200": {
-            "description": "Request published.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
-      }
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Request updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "No debt position found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "Request published.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}": {
-      "get": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "Return the details of a specific payment option.",
-        "operationId": "getOrganizationPaymentOptionByIUV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "401": {
-            "description": "Wrong or missing function key."
-          },
-          "404": {
-            "description": "No payment option found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "Obtained payment option details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
-      }
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}" : {
+      "get" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "Return the details of a specific payment option.",
+        "operationId" : "getOrganizationPaymentOptionByIUV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained payment option details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden."
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
           },
-          "401": {
-            "description": "Wrong or missing function key."
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/notificationfee" : {
+      "put" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization updates the notification fee of a payment option.",
+        "operationId" : "updateNotificationFee",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
-      }
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "422" : {
+            "description" : "Unprocessable payment option.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Request updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/pay" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The Organization paid a payment option.",
+        "operationId" : "payPaymentOption",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PayPaymentOptionModel"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "422" : {
+            "description" : "Unprocessable: not in payable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Request paid.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization reports a transaction.",
+        "operationId" : "reportTransfer",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "transferid",
+          "in" : "path",
+          "description" : "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request reported.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsTransferModelResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No transfer found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "NotificationFeeUpdateModel": {
-        "required": [
-          "notificationFee"
-        ],
-        "type": "object",
-        "properties": {
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+  "components" : {
+    "schemas" : {
+      "NotificationFeeUpdateModel" : {
+        "required" : [ "notificationFee" ],
+        "type" : "object",
+        "properties" : {
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PaymentsModelResponse": {
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
+      "PaymentsModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentsTransferModelResponse"
             }
           }
         }
       },
-      "PaymentsTransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "PaymentsTransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "type": "string",
-            "description": "Document hash"
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "type" : "string",
+            "description" : "Document hash"
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string",
-            "readOnly": true
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string",
+            "readOnly" : true
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with postalIban and stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with postalIban and stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "mutual exclusive with iban and stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with iban and stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           }
         }
       },
-      "PayPaymentOptionModel": {
-        "required": [
-          "idReceipt",
-          "pspCompany"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+      "PayPaymentOptionModel" : {
+        "required" : [ "idReceipt", "pspCompany" ],
+        "type" : "object",
+        "properties" : {
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "string"
+          "fee" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse": {
-        "type": "object",
-        "properties": {
-          "iuv": {
-            "type": "string"
+      "PaymentsWithDebtorInfoModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "iupd": {
-            "type": "string"
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "type": "string"
+          "country" : {
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "debtPositionStatus": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "debtPositionStatus" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentsTransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentsTransferModelResponse"
             }
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
       }
     }
   }

--- a/src/main/resources/application-h2.properties
+++ b/src/main/resources/application-h2.properties
@@ -1,4 +1,7 @@
 # info
+application.name=@project.artifactId@
+application.version=@project.version@
+application.description=@project.description@
 properties.environment=h2
 
 # Actuator

--- a/src/test/java/it/gov/pagopa/debtposition/OpenApiGenerationTest.java
+++ b/src/test/java/it/gov/pagopa/debtposition/OpenApiGenerationTest.java
@@ -1,0 +1,55 @@
+package it.gov.pagopa.debtposition;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OpenApiGenerationTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void swaggerSpringPlugin() throws Exception {
+        saveOpenAPI("/v3/api-docs", "openapi_internal.json");
+        saveOpenAPI("/v3/api-docs/external", "openapi_external.json");
+    }
+
+    private void saveOpenAPI(String fromUri, String toFile) throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get(fromUri).accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andDo(
+                        (result) -> {
+                            assertNotNull(result);
+                            assertNotNull(result.getResponse());
+                            final String content = result.getResponse().getContentAsString();
+                            assertFalse(content.isBlank());
+                            assertFalse(content.contains("${"), "Generated swagger contains placeholders");
+                            Object swagger =
+                                    objectMapper.readValue(result.getResponse().getContentAsString(), Object.class);
+                            String formatted =
+                                    objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(swagger);
+                            Path basePath = Paths.get("openapi/");
+                            Files.createDirectories(basePath);
+                            Files.write(basePath.resolve(toFile), formatted.getBytes());
+                        });
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -39,3 +39,14 @@ nav.aux.digit = 3
 
 # Flyway settings
 spring.flyway.enabled=false
+
+# Openapi
+springdoc.writer-with-order-by-keys=false
+springdoc.writer-with-default-pretty-printer=true
+springdoc.api-docs.groups.enabled=true
+springdoc.group-configs[0].group=internal
+springdoc.group-configs[0].displayName=GPD - Internal API
+springdoc.group-configs[0].paths-to-match=/*/**
+springdoc.group-configs[1].group=external
+springdoc.group-configs[1].displayName=GPD - External API
+springdoc.group-configs[1].paths-to-match=/organizations/{organizationfiscalcode}/debtpositions/**,/info


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Update `generate_openapi.sh`
- Update h2 properties file
-  ⚠️  Add `OpenApiGenerationTest` as in this [PR](https://github.com/pagopa/pagopa-api-config/pull/246) doesn't seem to work well: version and description are not read correctly from the `pom.xml`
- ⚠️  The X-Request-Id is only included in the internal documentation, in the external documentation it doesn't seem to be possible and this could be caused by the management via `springdoc.group-configs`

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- X-Request-Id header not included in the documentation
- Automation of the OpenAPI generation

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.