### PR TITLE
[PAGOPA-1967] feat: Update hashDocument max-length

### DIFF
--- a/src/main/java/it/gov/pagopa/debtposition/model/pd/Stamp.java
+++ b/src/main/java/it/gov/pagopa/debtposition/model/pd/Stamp.java
@@ -19,9 +19,11 @@ public class Stamp implements Serializable {
     private static final long serialVersionUID = -5862140737726963810L;
 
     @NotBlank
-    @Size(max = 64)
-    @Schema(required = true, description = "Document hash")
-    // hashDocument input is a sha256 -> maxsize 64 chars
+    @Size(max = 72)
+    @Schema(required = true, description = "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api.")
+    // Stamp generally get as input a base64sha256, that is the SHA256 hash of a given string encoded with Base64.
+    // It is not equivalent to base64encode(sha256(“test”)), if sha256() returns a hexadecimal representation.
+    // The result should normally be 44 characters, to be compliant with as-is it was extended to 72
     private String hashDocument;
 
     @NotBlank


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Update `hashDocument` max-length in `Stamp` type

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Stamp generally get as input a base64sha256, that is the SHA256 hash of a given string encoded with Base64.
It is not equivalent to base64encode(sha256(“test”)), if sha256() returns a hexadecimal representation.
The result should normally be 44 characters, to be compliant with as-is it was extended to 72

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.