### PR TITLE
[PIDM-42] fix(payment-status): payment position/option status not coherent

### DIFF
--- a/src/main/java/it/gov/pagopa/debtposition/service/payments/PaymentsService.java
+++ b/src/main/java/it/gov/pagopa/debtposition/service/payments/PaymentsService.java
@@ -6,6 +6,7 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.validation.Valid;
@@ -233,7 +234,10 @@ public class PaymentsService {
         }
 
         // aggiorno lo stato della payment position
-        if (countPaidPartialPayment > 0 && countPaidPartialPayment < numberOfPartialPayment) {
+        // PIDM-42 if paying the full amount when there is already a paid partial payment
+        // then update the payment position status to PAID
+        if (countPaidPartialPayment > 0 && countPaidPartialPayment < numberOfPartialPayment
+                && Boolean.TRUE.equals(Objects.requireNonNull(poToPay).getIsPartialPayment())) {
             pp.setStatus(DebtPositionStatus.PARTIALLY_PAID);
         } else {
             pp.setStatus(DebtPositionStatus.PAID);

--- a/src/main/java/it/gov/pagopa/debtposition/util/DebtPositionValidation.java
+++ b/src/main/java/it/gov/pagopa/debtposition/util/DebtPositionValidation.java
@@ -239,10 +239,28 @@ public class DebtPositionValidation {
         }
 
         // La posizione debitoria è già in PARTIALLY_PAID ed arriva una richiesta di pagamento su una payment option non rateizzata (isPartialPayment = false) => errore
-        if (ppToPay.getStatus().equals(DebtPositionStatus.PARTIALLY_PAID) && Boolean.FALSE.equals(poToPay.getIsPartialPayment())) {
-            throw new AppException(AppError.PAYMENT_OPTION_ALREADY_PAID, poToPay.getOrganizationFiscalCode(), nav);
-        }
+        // PIDM-42: if this is a full payment and the position is partially paid then
+        // log this but allow the payment option status to be changed to PO_PAID instead of throwing an error
+        if (ppToPay.getStatus().equals(DebtPositionStatus.PARTIALLY_PAID)
+                && Boolean.FALSE.equals(poToPay.getIsPartialPayment())) {
 
+            // log detailed information about this edge case
+            log.warn("Potential payment state inconsistency detected || " +
+                            "Organization: {} || " +
+                            "IUPD: {} || " +
+                            "NAV: {} || " +
+                            "Position Status: {} || " +
+                            "Payment Option Status: {} || " +
+                            "Is Partial Payment: {} || " +
+                            "Timestamp: {}",
+                    ppToPay.getOrganizationFiscalCode(),
+                    ppToPay.getIupd(),
+                    nav,
+                    ppToPay.getStatus(),
+                    poToPay.getStatus(),
+                    poToPay.getIsPartialPayment(),
+                    LocalDateTime.now());
+        }
     }
 
     private static boolean isPaid(PaymentOption po) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
These changes are relevant in case the user pays the full amount for a payment position in presence of already paid installments/payment options:
- Fixed payment option status not changing from PO_UNPAID to PO_PAID
- Added detailed logs for this specific case, instead of throwing an exception that makes the db not coherent with the payment process on the node
- Fixed payment position status not changing from PARTIALLY_PAID to PAID

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is a hotfix that was necessary to make the db coherent with what the user experiences during checkout. Before the fix, if the user paid using a NAV corresponding to the full amount due for the payment position but one or more installment/payment options were already paid for the same payment position, then the payment option corresponding to the full amount did not change status from PO_UNPAID to PAID, causing a discrepancy in the process. This happened because the checkout ended correctly up to the receipt generation for the user payment, but in the backend a HttpStatus.CONFLICT, "Existing related payment found" was being thrown.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested locally with Postman making the following use case:
- Create debt position with 4 payment options, option 1 being for the full amount and option 2/3/4 for the 3 installments
- Publish debt position
- Pay payment option 2 (corresponding to one installment)
- Retrieve payment option by NAV and check db status on the option
- Pay payment option 1 (corresponding to the full amount)
- Retrieve payment option by NAV and check db status on the option -> PO_PAID and debtPositionStatus -> PAID

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.