### PR TITLE
 feat: [PAGOPA-3108] Adding fields for GPD-Payments' checks on debt positions in ACA/Stand-In flow

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-gpd-core
 description: micro-service to manage Creditor Institution debtor positions
 type: application
-version: 0.217.0
-appVersion: 0.14.4
+version: 0.218.0
+appVersion: 0.14.5-PAGOPA-3108
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-debt-position
-    tag: "0.14.4"
+    tag: "0.14.5-PAGOPA-3108"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-debt-position
-    tag: "0.14.4"
+    tag: "0.14.5-PAGOPA-3108"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-debt-position
-    tag: "0.14.4"
+    tag: "0.14.5-PAGOPA-3108"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/integration-test/src/step_definitions/support/clients/gpd_client.js
+++ b/integration-test/src/step_definitions/support/clients/gpd_client.js
@@ -9,7 +9,7 @@ const API_TIMEOUT = process.env.api_timeout;
 const GPD_EXTERNAL_HOST = process.env.gpd_external_host;
 
 function gpdHealthCheck() {
-    return get(GPD_HOST + `/info`, {
+    return get(GPD_EXTERNAL_HOST + `/info`, {
         headers: {
             "Ocp-Apim-Subscription-Key": process.env.API_SUBSCRIPTION_KEY
         }
@@ -20,7 +20,7 @@ function createDebtPosition(orgId, body, segCodes, toPublish = false){
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
     if (toPublish) {params.toPublish = toPublish}
-    return post(GPD_HOST + `/organizations/${orgId}/debtpositions`, body, {
+    return post(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions`, body, {
         timeout: API_TIMEOUT,
         params,
         headers: {
@@ -46,7 +46,7 @@ function createMassiveDebtPositions(orgId, body, segCodes){
 function updateDebtPosition(orgId, iupd, body, segCodes) {
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
-    return put(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, body, {
+    return put(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, body, {
         timeout: API_TIMEOUT,
         params,
         headers: {
@@ -59,7 +59,7 @@ function updateDebtPosition(orgId, iupd, body, segCodes) {
 function publishDebtPosition(orgId, iupd, segCodes) {
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
-    return post(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}/publish`, "", {
+    return post(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}/publish`, "", {
         timeout: API_TIMEOUT,
         params,
         headers: {
@@ -72,7 +72,7 @@ function publishDebtPosition(orgId, iupd, segCodes) {
 function invalidateDebtPosition(orgId, iupd, segCodes) {
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
-    return post(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}/invalidate`, "", {
+    return post(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}/invalidate`, "", {
         timeout: API_TIMEOUT,
         params,
         headers: {
@@ -107,7 +107,7 @@ function getDebtPositionList(orgId, dueDateFrom, dueDateTo, paymentDateFrom, pay
 function getDebtPosition(orgId, iupd, segCodes) {
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
-    return get(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, {
+    return get(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, {
         timeout: API_TIMEOUT,
         headers: {
             "Ocp-Apim-Subscription-Key": process.env.API_SUBSCRIPTION_KEY,
@@ -119,7 +119,7 @@ function getDebtPosition(orgId, iupd, segCodes) {
 function getDebtPositionByIUV(orgId, iuv, segCodes) {
     const params = {}
     if (segCodes) {params.segregationCodes = segCodes}
-    return get(GPD_HOST + `/organizations/${orgId}/paymentoptions/${iuv}/debtposition`, {
+    return get(GPD_EXTERNAL_HOST + `/organizations/${orgId}/paymentoptions/${iuv}/debtposition`, {
         timeout: API_TIMEOUT,
         headers: {
             "Ocp-Apim-Subscription-Key": process.env.API_SUBSCRIPTION_KEY,
@@ -141,7 +141,7 @@ function getPaymentOptionByIuv(orgId, iuv) {
 function deleteDebtPosition(orgId, iupd, segCodes) {
 	const params = {}
 	if (segCodes) {params.segregationCodes = segCodes}
-    return del(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, {
+    return del(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, {
         timeout: API_TIMEOUT,
         params,
         headers: {
@@ -182,7 +182,7 @@ function updateNotificationFee(orgId, iuv, body) {
 }
 
 function createAndPublishDebtPosition(orgId, body) {
-    return post(GPD_HOST + `/organizations/${orgId}/debtpositions`, body, {
+    return post(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions`, body, {
         timeout: API_TIMEOUT,
         params: {
             toPublish: "True",
@@ -195,7 +195,7 @@ function createAndPublishDebtPosition(orgId, body) {
 }
 
 function updateAndPublishDebtPosition(orgId, iupd, body) {
-    return put(GPD_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, body, {
+    return put(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/${iupd}`, body, {
         timeout: API_TIMEOUT,
         params: {
             toPublish: "True",
@@ -208,7 +208,7 @@ function updateAndPublishDebtPosition(orgId, iupd, body) {
 }
 
 function updateTransferIbanMassive(orgId, oldIban, newIban) {
-    return patch(GPD_HOST + `/organizations/${orgId}/debtpositions/transfers?oldIban=${oldIban}&limit=10`, {newIban}, {
+    return patch(GPD_EXTERNAL_HOST + `/organizations/${orgId}/debtpositions/transfers?oldIban=${oldIban}&limit=10`, {newIban}, {
         timeout: API_TIMEOUT,
         headers: {
             "Ocp-Apim-Subscription-Key": process.env.API_SUBSCRIPTION_KEY,

--- a/openapi/openapi_aca_v1.json
+++ b/openapi/openapi_aca_v1.json
@@ -1,1854 +1,1690 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/aca/debt-positions-service/v1",
-      "description": "ACA Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/aca/debt-positions-service/v1",
-      "description": "ACA Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/aca/debt-positions-service/v1",
+    "description" : "ACA Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/aca/debt-positions-service/v1",
+    "description" : "ACA Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 50,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": false,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "INSERTED_DATE",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 50,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : false,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "INSERTED_DATE",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Position updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Position updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "PaymentOptionMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+  "components" : {
+    "schemas" : {
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "switchToExpired",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_aca_v1.json
+++ b/openapi/openapi_aca_v1.json
@@ -1,1690 +1,1854 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/aca/debt-positions-service/v1",
-    "description" : "ACA Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/aca/debt-positions-service/v1",
-    "description" : "ACA Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/aca/debt-positions-service/v1",
+      "description": "ACA Test environment"
     },
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId" : "getOrganizationDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of elements on one page. Default = 50",
-          "required" : false,
-          "schema" : {
-            "maximum" : 50,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Page number. Page value starts from 0",
-          "required" : false,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        }, {
-          "name" : "due_date_from",
-          "in" : "query",
-          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "due_date_to",
-          "in" : "query",
-          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_from",
-          "in" : "query",
-          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_to",
-          "in" : "query",
-          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "Filter by debt position status",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          }
-        }, {
-          "name" : "orderby",
-          "in" : "query",
-          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "INSERTED_DATE",
-            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
-          }
-        }, {
-          "name" : "ordering",
-          "in" : "query",
-          "description" : "Direction of ordering",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "DESC",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained all organization payment positions.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/aca/debt-positions-service/v1",
+      "description": "ACA Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization creates a debt Position.",
-        "operationId" : "createPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the details of a specific debt position.",
-        "operationId" : "getOrganizationDebtPositionByIUPD",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "INVALID",
+                "EXPIRED",
+                "PARTIALLY_PAID",
+                "PAID",
+                "REPORTED"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "INSERTED_DATE",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained debt position details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates a debt position ",
-        "operationId" : "updatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates a debt Position.",
+        "operationId": "createPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Position updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes a debt position",
-        "operationId" : "deletePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Operation completed successfully.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization invalidate a debt Position.",
-        "operationId" : "invalidatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in invalidable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Position updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization publish a debt Position.",
-        "operationId" : "publishPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization invalidate a debt Position.",
+        "operationId": "invalidatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in publishable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in invalidable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "PaymentOptionMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+  "components": {
+    "schemas": {
+      "PaymentOptionMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel" : {
-        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel" : {
-        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
-          },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the debt position to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
-          },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModel"
+          "paymentOptionMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "switchToExpired",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
+          },
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "value" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentOptionModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentPositionModelBaseResponse" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "officeName" : {
-            "type" : "string"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
-            }
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "idTransfer" : {
-            "type" : "string"
+          "officeName": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "remittanceInformation" : {
-            "type" : "string"
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "category" : {
-            "type" : "string"
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "iban" : {
-            "type" : "string"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "postalIban" : {
-            "type" : "string"
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            }
           },
-          "version" : {
-            "type" : "string"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        }
+      },
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+            }
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "string"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_external_v1.json
+++ b/openapi/openapi_external_v1.json
@@ -1,1853 +1,2029 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v1",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v1",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v1",
+      "description": "GPD Test environment"
     },
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId" : "getOrganizationDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of elements on one page. Default = 50",
-          "required" : false,
-          "schema" : {
-            "maximum" : 50,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Page number. Page value starts from 0",
-          "required" : false,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        }, {
-          "name" : "due_date_from",
-          "in" : "query",
-          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "due_date_to",
-          "in" : "query",
-          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_from",
-          "in" : "query",
-          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_to",
-          "in" : "query",
-          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "Filter by debt position status",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          }
-        }, {
-          "name" : "orderby",
-          "in" : "query",
-          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "INSERTED_DATE",
-            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
-          }
-        }, {
-          "name" : "ordering",
-          "in" : "query",
-          "description" : "Direction of ordering",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "DESC",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained all organization payment positions.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v1",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization creates a debt Position.",
-        "operationId" : "createPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
-      "patch" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId" : "updateTransferIbanMassive",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "INVALID",
+                "EXPIRED",
+                "PARTIALLY_PAID",
+                "PAID",
+                "REPORTED"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "INSERTED_DATE",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
           }
-        }, {
-          "name" : "oldIban",
-          "in" : "query",
-          "description" : "The old iban to replace",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
-          "required" : false,
-          "schema" : {
-            "maximum" : 1000,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 1000
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+                }
               }
             }
           },
-          "required" : true
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
         },
-        "responses" : {
-          "200" : {
-            "description" : "IBANs updated",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
+        "security": [
+          {
+            "ApiKey": []
           }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates a debt Position.",
+        "operationId": "createPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the details of a specific debt position.",
-        "operationId" : "getOrganizationDebtPositionByIUPD",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
+      "patch": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId": "updateTransferIbanMassive",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "oldIban",
+            "in": "query",
+            "description": "The old iban to replace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of Transfer to update (max = 1000, default = 1000)",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "type": "integer",
+              "format": "int32",
+              "default": 1000
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained debt position details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "IBANs updated",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates a debt position ",
-        "operationId" : "updatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Position updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes a debt position",
-        "operationId" : "deletePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Operation completed successfully.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization invalidate a debt Position.",
-        "operationId" : "invalidatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in invalidable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Position updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization publish a debt Position.",
-        "operationId" : "publishPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization invalidate a debt Position.",
+        "operationId": "invalidatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in publishable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in invalidable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "PaymentOptionMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+  "components": {
+    "schemas": {
+      "PaymentOptionMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel" : {
-        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel" : {
-        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
-          },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the debt position to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
-          },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModel"
+          "paymentOptionMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "switchToExpired",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
+          },
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "value" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel" : {
-        "required" : [ "newIban" ],
-        "type" : "object",
-        "properties" : {
-          "newIban" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveModel": {
+        "required": [
+          "newIban"
+        ],
+        "type": "object",
+        "properties": {
+          "newIban": {
+            "type": "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse" : {
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
           },
-          "updatedTransfers" : {
-            "type" : "integer",
-            "format" : "int32"
+          "updatedTransfers": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentOptionModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentPositionModelBaseResponse" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "officeName" : {
-            "type" : "string"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
-            }
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "idTransfer" : {
-            "type" : "string"
+          "officeName": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "remittanceInformation" : {
-            "type" : "string"
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "category" : {
-            "type" : "string"
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "iban" : {
-            "type" : "string"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "postalIban" : {
-            "type" : "string"
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            }
           },
-          "version" : {
-            "type" : "string"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        }
+      },
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+            }
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "string"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_external_v1.json
+++ b/openapi/openapi_external_v1.json
@@ -1,2029 +1,1853 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v1",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v1",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v1",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v1",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 50,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": false,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "INSERTED_DATE",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 50,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : false,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "INSERTED_DATE",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
-      "patch": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId": "updateTransferIbanMassive",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "oldIban",
-            "in": "query",
-            "description": "The old iban to replace",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of Transfer to update (max = 1000, default = 1000)",
-            "required": false,
-            "schema": {
-              "maximum": 1000,
-              "type": "integer",
-              "format": "int32",
-              "default": 1000
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
+      "patch" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId" : "updateTransferIbanMassive",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+        }, {
+          "name" : "oldIban",
+          "in" : "query",
+          "description" : "The old iban to replace",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
+          "required" : false,
+          "schema" : {
+            "maximum" : 1000,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 1000
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "IBANs updated",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "IBANs updated",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Position updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Position updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "PaymentOptionMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+  "components" : {
+    "schemas" : {
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "switchToExpired",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel": {
-        "required": [
-          "newIban"
-        ],
-        "type": "object",
-        "properties": {
-          "newIban": {
-            "type": "string"
+      "UpdateTransferIbanMassiveModel" : {
+        "required" : [ "newIban" ],
+        "type" : "object",
+        "properties" : {
+          "newIban" : {
+            "type" : "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
+      "UpdateTransferIbanMassiveResponse" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
           },
-          "updatedTransfers": {
-            "type": "integer",
-            "format": "int32"
+          "updatedTransfers" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_external_v2.json
+++ b/openapi/openapi_external_v2.json
@@ -1,1063 +1,1170 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v2",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v2",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v2",
+      "description": "GPD Test environment"
     },
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates multiple debt positions.",
-        "operationId" : "updateMultiplePositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v2",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization creates multiple debt positions.",
-        "operationId" : "createMultiplePositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes multiple debt positions.",
-        "operationId" : "deleteMultipleDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\b\\w{11}\\b",
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultipleIUPDModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions deleted.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Payment Position not found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates multiple debt positions.",
+        "operationId": "updateMultiplePositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Positions updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates multiple debt positions.",
+        "operationId": "createMultiplePositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes multiple debt positions.",
+        "operationId": "deleteMultipleDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\b\\w{11}\\b",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultipleIUPDModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Positions deleted.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Payment Position not found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "MultiplePaymentPositionModel" : {
-        "required" : [ "paymentPositions" ],
-        "type" : "object",
-        "properties" : {
-          "paymentPositions" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModel"
+  "components": {
+    "schemas": {
+      "MultiplePaymentPositionModel": {
+        "required": [
+          "paymentPositions"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentPositions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModel"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel" : {
-        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel" : {
-        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
-          },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the debt position to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
-          },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModel"
+          "paymentOptionMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "switchToExpired",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
+          },
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "value" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentOptionModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentPositionModelBaseResponse" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "officeName" : {
-            "type" : "string"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
-            }
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "idTransfer" : {
-            "type" : "string"
+          "officeName": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "remittanceInformation" : {
-            "type" : "string"
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "category" : {
-            "type" : "string"
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "iban" : {
-            "type" : "string"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "postalIban" : {
-            "type" : "string"
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            }
           },
-          "version" : {
-            "type" : "string"
-          },
-          "environment" : {
-            "type" : "string"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       },
-      "MultipleIUPDModel" : {
-        "required" : [ "paymentPositionIUPDs" ],
-        "type" : "object",
-        "properties" : {
-          "paymentPositionIUPDs" : {
-            "maxItems" : 20,
-            "minItems" : 0,
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+            }
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "string"
+          }
+        }
+      },
+      "MultipleIUPDModel": {
+        "required": [
+          "paymentPositionIUPDs"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentPositionIUPDs": {
+            "maxItems": 20,
+            "minItems": 0,
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_external_v2.json
+++ b/openapi/openapi_external_v2.json
@@ -1,1170 +1,1063 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v2",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v2",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v2",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v2",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates multiple debt positions.",
-        "operationId": "updateMultiplePositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates multiple debt positions.",
+        "operationId" : "updateMultiplePositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Positions updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates multiple debt positions.",
-        "operationId": "createMultiplePositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates multiple debt positions.",
+        "operationId" : "createMultiplePositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes multiple debt positions.",
-        "operationId": "deleteMultipleDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\b\\w{11}\\b",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes multiple debt positions.",
+        "operationId" : "deleteMultipleDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\b\\w{11}\\b",
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultipleIUPDModel"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultipleIUPDModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Positions deleted.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions deleted.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Payment Position not found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
+                }
+              }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Payment Position not found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : { }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "MultiplePaymentPositionModel": {
-        "required": [
-          "paymentPositions"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentPositions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModel"
+  "components" : {
+    "schemas" : {
+      "MultiplePaymentPositionModel" : {
+        "required" : [ "paymentPositions" ],
+        "type" : "object",
+        "properties" : {
+          "paymentPositions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModel"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "switchToExpired",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       },
-      "MultipleIUPDModel": {
-        "required": [
-          "paymentPositionIUPDs"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentPositionIUPDs": {
-            "maxItems": 20,
-            "minItems": 0,
-            "type": "array",
-            "items": {
-              "type": "string"
+      "MultipleIUPDModel" : {
+        "required" : [ "paymentPositionIUPDs" ],
+        "type" : "object",
+        "properties" : {
+          "paymentPositionIUPDs" : {
+            "maxItems" : 20,
+            "minItems" : 0,
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_external_v3.json
+++ b/openapi/openapi_external_v3.json
@@ -1,1493 +1,1646 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v3",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v3",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "get" : {
-        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
-        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId" : "getOrganizationDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of elements on one page. Default = 50",
-          "required" : false,
-          "schema" : {
-            "maximum" : 50,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Page number. Page value starts from 0",
-          "required" : false,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        }, {
-          "name" : "due_date_from",
-          "in" : "query",
-          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "due_date_to",
-          "in" : "query",
-          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_from",
-          "in" : "query",
-          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_to",
-          "in" : "query",
-          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "Filter by debt position status",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
-          }
-        }, {
-          "name" : "orderby",
-          "in" : "query",
-          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "INSERTED_DATE",
-            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
-          }
-        }, {
-          "name" : "ordering",
-          "in" : "query",
-          "description" : "Direction of ordering",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "DESC",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained all organization payment positions.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionsInfoV3"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "post" : {
-        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
-        "summary" : "The Organization creates a debt Position.",
-        "operationId" : "createPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModelV3"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v3",
+      "description": "GPD Test environment"
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
-      "get" : {
-        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
-        "summary" : "Return the details of a specific debt position.",
-        "operationId" : "getOrganizationDebtPositionByIUPD",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v3",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API: Installments and Payment Options Manager"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "UNPAYABLE",
+                "PARTIALLY_PAID",
+                "PAID"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "INSERTED_DATE",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained debt position details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelResponseV3"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfoV3"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
-        "summary" : "The Organization updates a debt position ",
-        "operationId" : "updatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "post": {
+        "tags": [
+          "Debt Positions API: Installments and Payment Options Manager"
+        ],
+        "summary": "The Organization creates a debt Position.",
+        "operationId": "createPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModelV3"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModelV3"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Position updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelV3"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
-        "summary" : "The Organization deletes a debt position",
-        "operationId" : "deletePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Operation completed successfully.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization publish a debt Position.",
-        "operationId" : "publishPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API: Installments and Payment Options Manager"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelResponseV3"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in publishable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API: Installments and Payment Options Manager"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModelV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Position updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelV3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API: Installments and Payment Options Manager"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelV3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "DebtorModel" : {
-        "required" : [ "fiscalCode", "fullName", "type" ],
-        "type" : "object",
-        "properties" : {
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
+  "components": {
+    "schemas": {
+      "DebtorModel": {
+        "required": [
+          "fiscalCode",
+          "fullName",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "fiscalCode" : {
-            "type" : "string"
+          "fiscalCode": {
+            "type": "string"
           },
-          "fullName" : {
-            "type" : "string"
+          "fullName": {
+            "type": "string"
           },
-          "streetName" : {
-            "type" : "string"
+          "streetName": {
+            "type": "string"
           },
-          "civicNumber" : {
-            "type" : "string"
+          "civicNumber": {
+            "type": "string"
           },
-          "postalCode" : {
-            "type" : "string"
+          "postalCode": {
+            "type": "string"
           },
-          "city" : {
-            "type" : "string"
+          "city": {
+            "type": "string"
           },
-          "province" : {
-            "type" : "string"
+          "province": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
           },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
           },
-          "phone" : {
-            "type" : "string"
+          "phone": {
+            "type": "string"
           }
         }
       },
-      "InstallmentMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "InstallmentMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "InstallmentModel" : {
-        "required" : [ "amount", "description", "dueDate", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "InstallmentModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "fee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "UNPAID", "PAID", "PARTIALLY_REPORTED", "REPORTED", "UNPAYABLE", "EXPIRED" ]
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "UNPAID",
+              "PAID",
+              "PARTIALLY_REPORTED",
+              "REPORTED",
+              "UNPAYABLE",
+              "EXPIRED"
+            ]
           },
-          "transfer" : {
-            "maxItems" : 2147483647,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "maxItems": 2147483647,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "installmentMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/InstallmentMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentOptionModelV3" : {
-        "required" : [ "debtor", "installments", "switchToExpired" ],
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string",
-            "writeOnly" : true
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the payment option to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "debtor" : {
-            "$ref" : "#/components/schemas/DebtorModel"
-          },
-          "installments" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/InstallmentModel"
+          "installmentMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/InstallmentMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModelV3" : {
-        "required" : [ "companyName", "iupd", "paymentOption" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
+      "PaymentOptionModelV3": {
+        "required": [
+          "debtor",
+          "installments",
+          "switchToExpired"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string",
+            "writeOnly": true
           },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the payment option to expire after the due date",
+            "example": false,
+            "default": false
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
+          "debtor": {
+            "$ref": "#/components/schemas/DebtorModel"
           },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
-          },
-          "paymentOption" : {
-            "maxItems" : 100,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelV3"
+          "installments": {
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstallmentModel"
             }
           }
         }
       },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "PaymentPositionModelV3": {
+        "required": [
+          "companyName",
+          "iupd",
+          "paymentOption"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
           },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "UNPAYABLE",
+              "PARTIALLY_PAID",
+              "PAID"
+            ]
+          },
+          "paymentOption": {
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelV3"
+            }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "value" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "InstallmentModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "InstallmentModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "UNPAID", "PAID", "PARTIALLY_REPORTED", "REPORTED", "UNPAYABLE", "EXPIRED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "UNPAID",
+              "PAID",
+              "PARTIALLY_REPORTED",
+              "REPORTED",
+              "UNPAYABLE",
+              "EXPIRED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "installmentMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/InstallmentMetadataModel"
+          "installmentMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstallmentMetadataModel"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
-          },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
-          },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
-          },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
-          }
-        }
-      },
-      "PaymentOptionModelResponseV3" : {
-        "type" : "object",
-        "properties" : {
-          "switchToExpired" : {
-            "type" : "boolean"
-          },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "debtor" : {
-            "$ref" : "#/components/schemas/DebtorModel"
-          },
-          "installments" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/InstallmentModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelResponseV3" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
           },
-          "companyName" : {
-            "type" : "string"
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "officeName" : {
-            "type" : "string"
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
+          }
+        }
+      },
+      "PaymentOptionModelResponseV3": {
+        "type": "object",
+        "properties": {
+          "switchToExpired": {
+            "type": "boolean"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
+          "debtor": {
+            "$ref": "#/components/schemas/DebtorModel"
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponseV3"
+          "installments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstallmentModelResponse"
             }
           }
         }
       },
-      "PaymentPositionsInfoV3" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelResponseV3"
+      "PaymentPositionModelResponseV3": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
+          },
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "UNPAYABLE",
+              "PARTIALLY_PAID",
+              "PAID"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponseV3"
+            }
+          }
+        }
+      },
+      "PaymentPositionsInfoV3": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelResponseV3"
             }
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "idTransfer" : {
-            "type" : "string"
+          "idTransfer": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "remittanceInformation" : {
-            "type" : "string"
+          "remittanceInformation": {
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string"
+          "iban": {
+            "type": "string"
           },
-          "postalIban" : {
-            "type" : "string"
+          "postalIban": {
+            "type": "string"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_external_v3.json
+++ b/openapi/openapi_external_v3.json
@@ -1,1646 +1,1493 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v3",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/gpd/debt-positions-service/v3",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API: Installments and Payment Options Manager"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 50,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": false,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "UNPAYABLE",
-                "PARTIALLY_PAID",
-                "PAID"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "INSERTED_DATE",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/gpd/debt-positions-service/v3",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/gpd/debt-positions-service/v3",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 50,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : false,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "INSERTED_DATE",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfoV3"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfoV3"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API: Installments and Payment Options Manager"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModelV3"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModelV3"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelV3"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API: Installments and Payment Options Manager"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelResponseV3"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelResponseV3"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API: Installments and Payment Options Manager"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModelV3"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModelV3"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Position updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Position updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelV3"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API: Installments and Payment Options Manager"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API: Installments and Payment Options Manager" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelV3"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelV3"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "DebtorModel": {
-        "required": [
-          "fiscalCode",
-          "fullName",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+  "components" : {
+    "schemas" : {
+      "DebtorModel" : {
+        "required" : [ "fiscalCode", "fullName", "type" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           }
         }
       },
-      "InstallmentMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "InstallmentMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "InstallmentModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "InstallmentModel" : {
+        "required" : [ "amount", "description", "dueDate", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "UNPAID",
-              "PAID",
-              "PARTIALLY_REPORTED",
-              "REPORTED",
-              "UNPAYABLE",
-              "EXPIRED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "UNPAID", "PAID", "PARTIALLY_REPORTED", "REPORTED", "UNPAYABLE", "EXPIRED" ]
           },
-          "transfer": {
-            "maxItems": 2147483647,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "maxItems" : 2147483647,
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "installmentMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/InstallmentMetadataModel"
+          "installmentMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/InstallmentMetadataModel"
             }
           }
         }
       },
-      "PaymentOptionModelV3": {
-        "required": [
-          "debtor",
-          "installments",
-          "switchToExpired"
-        ],
-        "type": "object",
-        "properties": {
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string",
-            "writeOnly": true
+      "PaymentOptionModelV3" : {
+        "required" : [ "debtor", "installments", "switchToExpired" ],
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string",
+            "writeOnly" : true
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the payment option to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the payment option to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "debtor": {
-            "$ref": "#/components/schemas/DebtorModel"
+          "debtor" : {
+            "$ref" : "#/components/schemas/DebtorModel"
           },
-          "installments": {
-            "maxItems": 100,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstallmentModel"
+          "installments" : {
+            "maxItems" : 100,
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InstallmentModel"
             }
           }
         }
       },
-      "PaymentPositionModelV3": {
-        "required": [
-          "companyName",
-          "iupd",
-          "paymentOption"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelV3" : {
+        "required" : [ "companyName", "iupd", "paymentOption" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "UNPAYABLE",
-              "PARTIALLY_PAID",
-              "PAID"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
           },
-          "paymentOption": {
-            "maxItems": 100,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelV3"
+          "paymentOption" : {
+            "maxItems" : 100,
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelV3"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "InstallmentModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "InstallmentModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "UNPAID",
-              "PAID",
-              "PARTIALLY_REPORTED",
-              "REPORTED",
-              "UNPAYABLE",
-              "EXPIRED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "UNPAID", "PAID", "PARTIALLY_REPORTED", "REPORTED", "UNPAYABLE", "EXPIRED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "installmentMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstallmentMetadataModel"
+          "installmentMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InstallmentMetadataModel"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentOptionModelResponseV3": {
-        "type": "object",
-        "properties": {
-          "switchToExpired": {
-            "type": "boolean"
+      "PaymentOptionModelResponseV3" : {
+        "type" : "object",
+        "properties" : {
+          "switchToExpired" : {
+            "type" : "boolean"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "debtor": {
-            "$ref": "#/components/schemas/DebtorModel"
+          "debtor" : {
+            "$ref" : "#/components/schemas/DebtorModel"
           },
-          "installments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InstallmentModelResponse"
+          "installments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InstallmentModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelResponseV3": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelResponseV3" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "UNPAYABLE",
-              "PARTIALLY_PAID",
-              "PAID"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "UNPAYABLE", "PARTIALLY_PAID", "PAID" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponseV3"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponseV3"
             }
           }
         }
       },
-      "PaymentPositionsInfoV3": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelResponseV3"
+      "PaymentPositionsInfoV3" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelResponseV3"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_internal_v1.json
+++ b/openapi/openapi_internal_v1.json
@@ -2686,6 +2686,9 @@
           "idFlowReporting" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
           "status" : {
             "type" : "string",
             "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]

--- a/openapi/openapi_internal_v1.json
+++ b/openapi/openapi_internal_v1.json
@@ -1,3193 +1,2942 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/gpd/api/v1",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/gpd/api/v1",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/gpd/api/v1",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/gpd/api/v1",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/internal/config/send": {
-      "post": {
-        "tags": [
-          "Configuration"
-        ],
-        "summary": "Configures payment options for which communication with SeND is synchronous",
-        "operationId": "handleSyncSendConfiguration",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "maximum": 1000,
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Notice"
+    "/internal/config/send" : {
+      "post" : {
+        "tags" : [ "Configuration" ],
+        "summary" : "Configures payment options for which communication with SeND is synchronous",
+        "operationId" : "handleSyncSendConfiguration",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "maximum" : 1000,
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/Notice"
                 }
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 50,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": false,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "INSERTED_DATE",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 50,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : false,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "INSERTED_DATE",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates a debt Position.",
-        "operationId": "createPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates a debt Position.",
+        "operationId" : "createPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
-      "patch": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId": "updateTransferIbanMassive",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "oldIban",
-            "in": "query",
-            "description": "The old iban to replace",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of Transfer to update (max = 1000, default = 1000)",
-            "required": false,
-            "schema": {
-              "maximum": 1000,
-              "type": "integer",
-              "format": "int32",
-              "default": 1000
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
+      "patch" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId" : "updateTransferIbanMassive",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+        }, {
+          "name" : "oldIban",
+          "in" : "query",
+          "description" : "The old iban to replace",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
+          "required" : false,
+          "schema" : {
+            "maximum" : 1000,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 1000
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "IBANs updated",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "IBANs updated",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Position updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Position updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The organization retrieves a debt position by payment option IUV",
-        "operationId": "getDebtPositionByIUV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\d{11}",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "Payment Option IUV",
-            "required": true,
-            "schema": {
-              "pattern": "\\b\\w{0,35}\\b",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The organization retrieves a debt position by payment option IUV",
+        "operationId" : "getDebtPositionByIUV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\d{11}",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Debt Positions updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "Payment Option IUV",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\b\\w{0,35}\\b",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "Payment Position not found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Payment Position not found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization reports a transaction.",
-        "operationId": "reportTransfer",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "transferid",
-            "in": "path",
-            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization reports a transaction.",
+        "operationId" : "reportTransfer",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request reported.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "transferid",
+          "in" : "path",
+          "description" : "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request reported.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TransferModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransferModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No transfer found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No transfer found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
-      "get": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "Return the details of a specific payment option.",
-        "operationId": "getOrganizationPaymentOptionByNAV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\d{1,30}",
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "pattern": "^\\d{1,30}$",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
+      "get" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "Return the details of a specific payment option.",
+        "operationId" : "getOrganizationPaymentOptionByNAV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\d{1,30}",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained payment option details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "^\\d{1,30}$",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained payment option details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
-      "put": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization updates the notification fee of a payment option.",
-        "operationId": "updateNotificationFee",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
+      "put" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization updates the notification fee of a payment option.",
+        "operationId" : "updateNotificationFee",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Request updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Request updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "209": {
-            "description": "Request updated with a payment in progress.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "209" : {
+            "description" : "Request updated with a payment in progress.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable payment option.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "422" : {
+            "description" : "Unprocessable payment option.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The Organization paid a payment option.",
-        "operationId": "payPaymentOption",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The Organization paid a payment option.",
+        "operationId" : "payPaymentOption",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PayPaymentOptionModel"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PayPaymentOptionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Request paid.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Request paid.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable: not in payable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "422" : {
+            "description" : "Unprocessable: not in payable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "NotificationFeeUpdateModel": {
-        "required": [
-          "notificationFee"
-        ],
-        "type": "object",
-        "properties": {
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+  "components" : {
+    "schemas" : {
+      "NotificationFeeUpdateModel" : {
+        "required" : [ "notificationFee" ],
+        "type" : "object",
+        "properties" : {
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentsModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "lastUpdatedDateNotificationFee": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDateNotificationFee" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "switchToExpired",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "PayPaymentOptionModel": {
-        "required": [
-          "idReceipt",
-          "pspCompany"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+      "PayPaymentOptionModel" : {
+        "required" : [ "idReceipt", "pspCompany" ],
+        "type" : "object",
+        "properties" : {
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "pspCode": {
-            "type": "string"
+          "pspCode" : {
+            "maxLength" : 35,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "pspTaxCode": {
-            "type": "string"
+          "pspTaxCode" : {
+            "maxLength" : 70,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "string"
+          "fee" : {
+            "type" : "string"
           }
         }
       },
-      "Notice": {
-        "required": [
-          "nav",
-          "organizationFiscalCode"
-        ],
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "Notice" : {
+        "required" : [ "nav", "organizationFiscalCode" ],
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "nav": {
-            "type": "string"
+          "nav" : {
+            "type" : "string"
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel": {
-        "required": [
-          "newIban"
-        ],
-        "type": "object",
-        "properties": {
-          "newIban": {
-            "type": "string"
+      "UpdateTransferIbanMassiveModel" : {
+        "required" : [ "newIban" ],
+        "type" : "object",
+        "properties" : {
+          "newIban" : {
+            "type" : "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
+      "UpdateTransferIbanMassiveResponse" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
           },
-          "updatedTransfers": {
-            "type": "integer",
-            "format": "int32"
+          "updatedTransfers" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsWithDebtorInfoModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "payStandIn" : {
+            "type" : "boolean"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "idReceipt": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          },
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "iupd": {
-            "type": "string"
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "type": "string"
+          "country" : {
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "debtPositionStatus": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "debtPositionStatus" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_internal_v1.json
+++ b/openapi/openapi_internal_v1.json
@@ -1,2945 +1,3203 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/gpd/api/v1",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/gpd/api/v1",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/gpd/api/v1",
+      "description": "GPD Test environment"
     },
-    "/internal/config/send" : {
-      "post" : {
-        "tags" : [ "Configuration" ],
-        "summary" : "Configures payment options for which communication with SeND is synchronous",
-        "operationId" : "handleSyncSendConfiguration",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "maximum" : 1000,
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/Notice"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/gpd/api/v1",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId" : "getOrganizationDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of elements on one page. Default = 50",
-          "required" : false,
-          "schema" : {
-            "maximum" : 50,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Page number. Page value starts from 0",
-          "required" : false,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        }, {
-          "name" : "due_date_from",
-          "in" : "query",
-          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "due_date_to",
-          "in" : "query",
-          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_from",
-          "in" : "query",
-          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_to",
-          "in" : "query",
-          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "Filter by debt position status",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          }
-        }, {
-          "name" : "orderby",
-          "in" : "query",
-          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "INSERTED_DATE",
-            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
-          }
-        }, {
-          "name" : "ordering",
-          "in" : "query",
-          "description" : "Direction of ordering",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "DESC",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained all organization payment positions.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    "/internal/config/send": {
+      "post": {
+        "tags": [
+          "Configuration"
+        ],
+        "summary": "Configures payment options for which communication with SeND is synchronous",
+        "operationId": "handleSyncSendConfiguration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "maximum": 1000,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Notice"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization creates a debt Position.",
-        "operationId" : "createPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
-      "patch" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId" : "updateTransferIbanMassive",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "INVALID",
+                "EXPIRED",
+                "PARTIALLY_PAID",
+                "PAID",
+                "REPORTED"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "INSERTED_DATE",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
           }
-        }, {
-          "name" : "oldIban",
-          "in" : "query",
-          "description" : "The old iban to replace",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
-          "required" : false,
-          "schema" : {
-            "maximum" : 1000,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 1000
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+                }
               }
             }
           },
-          "required" : true
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
         },
-        "responses" : {
-          "200" : {
-            "description" : "IBANs updated",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
+        "security": [
+          {
+            "ApiKey": []
           }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates a debt Position.",
+        "operationId": "createPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the details of a specific debt position.",
-        "operationId" : "getOrganizationDebtPositionByIUPD",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
+      "patch": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId": "updateTransferIbanMassive",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "oldIban",
+            "in": "query",
+            "description": "The old iban to replace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of Transfer to update (max = 1000, default = 1000)",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "type": "integer",
+              "format": "int32",
+              "default": 1000
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained debt position details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "IBANs updated",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates a debt position ",
-        "operationId" : "updatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Position updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes a debt position",
-        "operationId" : "deletePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Operation completed successfully.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization invalidate a debt Position.",
-        "operationId" : "invalidatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in invalidable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Position updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization publish a debt Position.",
-        "operationId" : "publishPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization invalidate a debt Position.",
+        "operationId": "invalidatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in publishable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in invalidable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The organization retrieves a debt position by payment option IUV",
-        "operationId" : "getDebtPositionByIUV",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\d{11}",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iuv",
-          "in" : "path",
-          "description" : "Payment Option IUV",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\b\\w{0,35}\\b",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Payment Position not found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report" : {
-      "post" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The organization reports a transaction.",
-        "operationId" : "reportTransfer",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The organization retrieves a debt position by payment option IUV",
+        "operationId": "getDebtPositionByIUV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\d{11}",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "Payment Option IUV",
+            "required": true,
+            "schema": {
+              "pattern": "\\b\\w{0,35}\\b",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iuv",
-          "in" : "path",
-          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "transferid",
-          "in" : "path",
-          "description" : "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request reported.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Debt Positions updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TransferModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {}
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No transfer found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "Payment Position not found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {}
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
+            "content": {
+              "application/json": {}
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
-      "get" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "Return the details of a specific payment option.",
-        "operationId" : "getOrganizationPaymentOptionByNAV",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\d{1,30}",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization reports a transaction.",
+        "operationId": "reportTransfer",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "transferid",
+            "in": "path",
+            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "^\\d{1,30}$",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained payment option details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request reported.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferModelResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No transfer found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
-      "put" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The organization updates the notification fee of a payment option.",
-        "operationId" : "updateNotificationFee",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
+      "get": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "Return the details of a specific payment option.",
+        "operationId": "getOrganizationPaymentOptionByNAV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\d{1,30}",
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{1,30}$",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Request updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained payment option details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "209" : {
-            "description" : "Request updated with a payment in progress.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "422" : {
-            "description" : "Unprocessable payment option.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay" : {
-      "post" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The Organization paid a payment option.",
-        "operationId" : "payPaymentOption",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
+      "put": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization updates the notification fee of a payment option.",
+        "operationId": "updateNotificationFee",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PayPaymentOptionModel"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "Request paid.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        "responses": {
+          "200": {
+            "description": "Request updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "209": {
+            "description": "Request updated with a payment in progress.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422" : {
-            "description" : "Unprocessable: not in payable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "422": {
+            "description": "Unprocessable payment option.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The Organization paid a payment option.",
+        "operationId": "payPaymentOption",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PayPaymentOptionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Request paid.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable: not in payable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "NotificationFeeUpdateModel" : {
-        "required" : [ "notificationFee" ],
-        "type" : "object",
-        "properties" : {
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+  "components": {
+    "schemas": {
+      "NotificationFeeUpdateModel": {
+        "required": [
+          "notificationFee"
+        ],
+        "type": "object",
+        "properties": {
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentsModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentsModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastUpdatedDateNotificationFee" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDateNotificationFee": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
-          },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
-          },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "idTransfer" : {
-            "type" : "string"
-          },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "remittanceInformation" : {
-            "type" : "string"
-          },
-          "category" : {
-            "type" : "string"
-          },
-          "iban" : {
-            "type" : "string"
-          },
-          "postalIban" : {
-            "type" : "string"
-          },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "value" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+            }
+          }
+        }
+      },
+      "PaymentOptionMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel" : {
-        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel" : {
-        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
-          },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the debt position to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
-          },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModel"
+          "paymentOptionMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "switchToExpired",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
+          },
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "PayPaymentOptionModel" : {
-        "required" : [ "idReceipt", "pspCompany" ],
-        "type" : "object",
-        "properties" : {
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+      "PayPaymentOptionModel": {
+        "required": [
+          "idReceipt",
+          "pspCompany"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "pspCode" : {
-            "maxLength" : 35,
-            "minLength" : 0,
-            "type" : "string"
+          "pspCode": {
+            "maxLength": 35,
+            "minLength": 0,
+            "type": "string"
           },
-          "pspTaxCode" : {
-            "maxLength" : 70,
-            "minLength" : 0,
-            "type" : "string"
+          "pspTaxCode": {
+            "maxLength": 70,
+            "minLength": 0,
+            "type": "string"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "string"
+          "fee": {
+            "type": "string"
           }
         }
       },
-      "Notice" : {
-        "required" : [ "nav", "organizationFiscalCode" ],
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+      "Notice": {
+        "required": [
+          "nav",
+          "organizationFiscalCode"
+        ],
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "nav" : {
-            "type" : "string"
+          "nav": {
+            "type": "string"
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel" : {
-        "required" : [ "newIban" ],
-        "type" : "object",
-        "properties" : {
-          "newIban" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveModel": {
+        "required": [
+          "newIban"
+        ],
+        "type": "object",
+        "properties": {
+          "newIban": {
+            "type": "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse" : {
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
           },
-          "updatedTransfers" : {
-            "type" : "integer",
-            "format" : "int32"
+          "updatedTransfers": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentsWithDebtorInfoModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "payStandIn" : {
-            "type" : "boolean"
+          "payStandIn": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "serviceType" : {
-            "type" : "string"
+          "serviceType": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "iupd" : {
-            "type" : "string"
+          "iupd": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "fiscalCode" : {
-            "type" : "string"
+          "fiscalCode": {
+            "type": "string"
           },
-          "fullName" : {
-            "type" : "string"
+          "fullName": {
+            "type": "string"
           },
-          "streetName" : {
-            "type" : "string"
+          "streetName": {
+            "type": "string"
           },
-          "civicNumber" : {
-            "type" : "string"
+          "civicNumber": {
+            "type": "string"
           },
-          "postalCode" : {
-            "type" : "string"
+          "postalCode": {
+            "type": "string"
           },
-          "city" : {
-            "type" : "string"
+          "city": {
+            "type": "string"
           },
-          "province" : {
-            "type" : "string"
+          "province": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "country" : {
-            "type" : "string"
+          "country": {
+            "type": "string"
           },
-          "email" : {
-            "type" : "string"
+          "email": {
+            "type": "string"
           },
-          "phone" : {
-            "type" : "string"
+          "phone": {
+            "type": "string"
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "officeName" : {
-            "type" : "string"
+          "officeName": {
+            "type": "string"
           },
-          "debtPositionStatus" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          "debtPositionStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentOptionModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
-          },
-          "iuv" : {
-            "type" : "string"
-          },
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "isPartialPayment" : {
-            "type" : "boolean"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentMethod" : {
-            "type" : "string"
-          },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "pspCompany" : {
-            "type" : "string"
-          },
-          "idReceipt" : {
-            "type" : "string"
-          },
-          "idFlowReporting" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
-            }
-          },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "companyName" : {
-            "type" : "string"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "officeName" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+            }
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+            }
           }
         }
       },
-      "PaymentPositionsInfo" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
+          },
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
+          }
+        }
+      },
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_internal_v2.json
+++ b/openapi/openapi_internal_v2.json
@@ -1,3216 +1,3491 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/gpd/api/v2",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/gpd/api/v2",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/gpd/api/v2",
+      "description": "GPD Test environment"
     },
-    "/internal/config/send" : {
-      "post" : {
-        "tags" : [ "Configuration" ],
-        "summary" : "Configures payment options for which communication with SeND is synchronous",
-        "operationId" : "handleSyncSendConfiguration",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "maximum" : 1000,
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/components/schemas/Notice"
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/gpd/api/v2",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId" : "getOrganizationDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of elements on one page. Default = 50",
-          "required" : false,
-          "schema" : {
-            "maximum" : 50,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "Page number. Page value starts from 0",
-          "required" : false,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        }, {
-          "name" : "due_date_from",
-          "in" : "query",
-          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "due_date_to",
-          "in" : "query",
-          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_from",
-          "in" : "query",
-          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "payment_date_to",
-          "in" : "query",
-          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "format" : "date"
-          }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "Filter by debt position status",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          }
-        }, {
-          "name" : "orderby",
-          "in" : "query",
-          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "INSERTED_DATE",
-            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
-          }
-        }, {
-          "name" : "ordering",
-          "in" : "query",
-          "description" : "Direction of ordering",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "DESC",
-            "enum" : [ "ASC", "DESC" ]
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained all organization payment positions.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    "/internal/config/send": {
+      "post": {
+        "tags": [
+          "Configuration"
+        ],
+        "summary": "Configures payment options for which communication with SeND is synchronous",
+        "operationId": "handleSyncSendConfiguration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "maximum": 1000,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Notice"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates multiple debt positions.",
-        "operationId" : "updateMultiplePositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "post" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization creates multiple debt positions.",
-        "operationId" : "createMultiplePositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Request created.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: duplicate debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes multiple debt positions.",
-        "operationId" : "deleteMultipleDebtPositions",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\b\\w{11}\\b",
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/MultipleIUPDModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions deleted.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Payment Position not found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : { }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
-      "patch" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId" : "updateTransferIbanMassive",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId": "getOrganizationDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of elements on one page. Default = 50",
+            "required": false,
+            "schema": {
+              "maximum": 50,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Page value starts from 0",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "due_date_from",
+            "in": "query",
+            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "due_date_to",
+            "in": "query",
+            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_from",
+            "in": "query",
+            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "payment_date_to",
+            "in": "query",
+            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by debt position status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "DRAFT",
+                "PUBLISHED",
+                "VALID",
+                "INVALID",
+                "EXPIRED",
+                "PARTIALLY_PAID",
+                "PAID",
+                "REPORTED"
+              ]
+            }
+          },
+          {
+            "name": "orderby",
+            "in": "query",
+            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "INSERTED_DATE",
+              "enum": [
+                "INSERTED_DATE",
+                "IUPD",
+                "STATUS",
+                "COMPANY_NAME"
+              ]
+            }
+          },
+          {
+            "name": "ordering",
+            "in": "query",
+            "description": "Direction of ordering",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "DESC",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            }
           }
-        }, {
-          "name" : "oldIban",
-          "in" : "query",
-          "description" : "The old iban to replace",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
-          "required" : false,
-          "schema" : {
-            "maximum" : 1000,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 1000
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained all organization payment positions.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+                }
               }
             }
           },
-          "required" : true
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
         },
-        "responses" : {
-          "200" : {
-            "description" : "IBANs updated",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
+        "security": [
+          {
+            "ApiKey": []
           }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates multiple debt positions.",
+        "operationId": "updateMultiplePositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Positions updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization creates multiple debt positions.",
+        "operationId": "createMultiplePositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: duplicate debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes multiple debt positions.",
+        "operationId": "deleteMultipleDebtPositions",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\b\\w{11}\\b",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultipleIUPDModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Positions deleted.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Payment Position not found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {}
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "Return the details of a specific debt position.",
-        "operationId" : "getOrganizationDebtPositionByIUPD",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
+      "patch": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId": "updateTransferIbanMassive",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "oldIban",
+            "in": "query",
+            "description": "The old iban to replace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of Transfer to update (max = 1000, default = 1000)",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "type": "integer",
+              "format": "int32",
+              "default": 1000
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained debt position details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "IBANs updated",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization updates a debt position ",
-        "operationId" : "updatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "toPublish",
-          "in" : "query",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : false
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PaymentPositionModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Debt Position updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The Organization deletes a debt position",
-        "operationId" : "deletePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "[\\w*\\h-]+",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Operation completed successfully.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No debt position position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization invalidate a debt Position.",
-        "operationId" : "invalidatePosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "Return the details of a specific debt position.",
+        "operationId": "getOrganizationDebtPositionByIUPD",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained debt position details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in invalidable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "put": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization updates a debt position ",
+        "operationId": "updatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "toPublish",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentPositionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Debt Position updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The Organization deletes a debt position",
+        "operationId": "deletePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "pattern": "[\\w*\\h-]+",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation completed successfully.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No debt position position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
-      "post" : {
-        "tags" : [ "Debt Position Actions API" ],
-        "summary" : "The Organization publish a debt Position.",
-        "operationId" : "publishPosition",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization invalidate a debt Position.",
+        "operationId": "invalidatePosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iupd",
-          "in" : "path",
-          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request published.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No debt position found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: debt position is not in publishable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in invalidable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition" : {
-      "get" : {
-        "tags" : [ "Debt Positions API" ],
-        "summary" : "The organization retrieves a debt position by payment option IUV",
-        "operationId" : "getDebtPositionByIUV",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\d{11}",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
+      "post": {
+        "tags": [
+          "Debt Position Actions API"
+        ],
+        "summary": "The Organization publish a debt Position.",
+        "operationId": "publishPosition",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iupd",
+            "in": "path",
+            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iuv",
-          "in" : "path",
-          "description" : "Payment Option IUV",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\b\\w{0,35}\\b",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Debt Positions updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request published.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No debt position found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "example" : {
-                  "statusCode" : 403,
-                  "message" : "You are not allowed to access this resource."
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "Payment Position not found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "409": {
+            "description": "Conflict: debt position is not in publishable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : { }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report" : {
-      "post" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The organization reports a transaction.",
-        "operationId" : "reportTransfer",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition": {
+      "get": {
+        "tags": [
+          "Debt Positions API"
+        ],
+        "summary": "The organization retrieves a debt position by payment option IUV",
+        "operationId": "getDebtPositionByIUV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\d{11}",
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "Payment Option IUV",
+            "required": true,
+            "schema": {
+              "pattern": "\\b\\w{0,35}\\b",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "iuv",
-          "in" : "path",
-          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "transferid",
-          "in" : "path",
-          "description" : "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Request reported.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Debt Positions updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/TransferModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {}
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No transfer found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "Payment Position not found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {}
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
+            "content": {
+              "application/json": {}
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
-      "get" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "Return the details of a specific payment option.",
-        "operationId" : "getOrganizationPaymentOptionByNAV",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\d{1,30}",
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization reports a transaction.",
+        "operationId": "reportTransfer",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "iuv",
+            "in": "path",
+            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "transferid",
+            "in": "path",
+            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "^\\d{1,30}$",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained payment option details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request reported.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferModelResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No transfer found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
-      "put" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The organization updates the notification fee of a payment option.",
-        "operationId" : "updateNotificationFee",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
+      "get": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "Return the details of a specific payment option.",
+        "operationId": "getOrganizationPaymentOptionByNAV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\d{1,30}",
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{1,30}$",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Request updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained payment option details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "209" : {
-            "description" : "Request updated with a payment in progress.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "422" : {
-            "description" : "Unprocessable payment option.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay" : {
-      "post" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The Organization paid a payment option.",
-        "operationId" : "payPaymentOption",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
+      "put": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization updates the notification fee of a payment option.",
+        "operationId": "updateNotificationFee",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PayPaymentOptionModel"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "Request paid.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        "responses": {
+          "200": {
+            "description": "Request updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "209": {
+            "description": "Request updated with a payment in progress.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "409" : {
-            "description" : "Conflict: existing related payment found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422" : {
-            "description" : "Unprocessable: not in payable state.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "422": {
+            "description": "Unprocessable payment option.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay": {
+      "post": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The Organization paid a payment option.",
+        "operationId": "payPaymentOption",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PayPaymentOptionModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Request paid.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict: existing related payment found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable: not in payable state.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "NotificationFeeUpdateModel" : {
-        "required" : [ "notificationFee" ],
-        "type" : "object",
-        "properties" : {
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+  "components": {
+    "schemas": {
+      "NotificationFeeUpdateModel": {
+        "required": [
+          "notificationFee"
+        ],
+        "type": "object",
+        "properties": {
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentsModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentsModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastUpdatedDateNotificationFee" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDateNotificationFee": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
-          },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
-          },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "idTransfer" : {
-            "type" : "string"
-          },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "remittanceInformation" : {
-            "type" : "string"
-          },
-          "category" : {
-            "type" : "string"
-          },
-          "iban" : {
-            "type" : "string"
-          },
-          "postalIban" : {
-            "type" : "string"
-          },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "MultiplePaymentPositionModel" : {
-        "required" : [ "paymentPositions" ],
-        "type" : "object",
-        "properties" : {
-          "paymentPositions" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModel"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+          },
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
+          },
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "idTransfer": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "remittanceInformation": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "iban": {
+            "type": "string"
+          },
+          "postalIban": {
+            "type": "string"
+          },
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "MultiplePaymentPositionModel": {
+        "required": [
+          "paymentPositions"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentPositions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModel"
+            }
+          }
+        }
+      },
+      "PaymentOptionMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel" : {
-        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentOptionModel": {
+        "required": [
+          "amount",
+          "description",
+          "dueDate",
+          "isPartialPayment",
+          "iuv"
+        ],
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "description": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64",
-            "readOnly" : true
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModel"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
-            }
-          }
-        }
-      },
-      "PaymentPositionModel" : {
-        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "payStandIn" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable a debt position in stand-in mode",
-            "example" : true,
-            "default" : true
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "example" : "IT"
-          },
-          "email" : {
-            "type" : "string",
-            "example" : "email@domain.com"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "switchToExpired" : {
-            "type" : "boolean",
-            "description" : "feature flag to enable the debt position to expire after the due date",
-            "example" : false,
-            "default" : false
-          },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "officeName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
-          },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time",
-            "readOnly" : true
-          },
-          "status" : {
-            "type" : "string",
-            "readOnly" : true,
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModel"
+          "paymentOptionMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "TransferMetadataModel" : {
-        "required" : [ "key" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentPositionModel": {
+        "required": [
+          "companyName",
+          "fiscalCode",
+          "fullName",
+          "iupd",
+          "switchToExpired",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "payStandIn": {
+            "type": "boolean",
+            "description": "feature flag to enable a debt position in stand-in mode",
+            "example": true,
+            "default": true
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "example": "IT"
+          },
+          "email": {
+            "type": "string",
+            "example": "email@domain.com"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "switchToExpired": {
+            "type": "boolean",
+            "description": "feature flag to enable the debt position to expire after the due date",
+            "example": false,
+            "default": false
+          },
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "officeName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "status": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModel"
+            }
+          }
+        }
+      },
+      "TransferMetadataModel": {
+        "required": [
+          "key"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         },
-        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+        "description": "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel" : {
-        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
-        "type" : "object",
-        "properties" : {
-          "idTransfer" : {
-            "type" : "string",
-            "enum" : [ "1", "2", "3", "4", "5" ]
+      "TransferModel": {
+        "required": [
+          "amount",
+          "category",
+          "idTransfer",
+          "remittanceInformation"
+        ],
+        "type": "object",
+        "properties": {
+          "idTransfer": {
+            "type": "string",
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ]
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "organizationFiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code related to the organization targeted by this transfer.",
-            "example" : "00000000000"
+          "organizationFiscalCode": {
+            "type": "string",
+            "description": "Fiscal code related to the organization targeted by this transfer.",
+            "example": "00000000000"
           },
-          "remittanceInformation" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "remittanceInformation": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "category" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           },
-          "iban" : {
-            "type" : "string",
-            "description" : "mutual exclusive with stamp",
-            "example" : "IT0000000000000000000000000"
+          "iban": {
+            "type": "string",
+            "description": "mutual exclusive with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "postalIban" : {
-            "type" : "string",
-            "description" : "optional - can be combined with iban but not with stamp",
-            "example" : "IT0000000000000000000000000"
+          "postalIban": {
+            "type": "string",
+            "description": "optional - can be combined with iban but not with stamp",
+            "example": "IT0000000000000000000000000"
           },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "companyName" : {
-            "maxLength" : 140,
-            "minLength" : 0,
-            "type" : "string"
+          "companyName": {
+            "maxLength": 140,
+            "minLength": 0,
+            "type": "string"
           },
-          "transferMetadata" : {
-            "maxItems" : 10,
-            "minItems" : 0,
-            "type" : "array",
-            "description" : "it can added a maximum of 10 key-value pairs for metadata",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModel"
+          "transferMetadata": {
+            "maxItems": 10,
+            "minItems": 0,
+            "type": "array",
+            "description": "it can added a maximum of 10 key-value pairs for metadata",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "PayPaymentOptionModel" : {
-        "required" : [ "idReceipt", "pspCompany" ],
-        "type" : "object",
-        "properties" : {
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+      "PayPaymentOptionModel": {
+        "required": [
+          "idReceipt",
+          "pspCompany"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "pspCode" : {
-            "maxLength" : 35,
-            "minLength" : 0,
-            "type" : "string"
+          "pspCode": {
+            "maxLength": 35,
+            "minLength": 0,
+            "type": "string"
           },
-          "pspTaxCode" : {
-            "maxLength" : 70,
-            "minLength" : 0,
-            "type" : "string"
+          "pspTaxCode": {
+            "maxLength": 70,
+            "minLength": 0,
+            "type": "string"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "string"
+          "fee": {
+            "type": "string"
           }
         }
       },
-      "Notice" : {
-        "required" : [ "nav", "organizationFiscalCode" ],
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
+      "Notice": {
+        "required": [
+          "nav",
+          "organizationFiscalCode"
+        ],
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "nav" : {
-            "type" : "string"
+          "nav": {
+            "type": "string"
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel" : {
-        "required" : [ "newIban" ],
-        "type" : "object",
-        "properties" : {
-          "newIban" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveModel": {
+        "required": [
+          "newIban"
+        ],
+        "type": "object",
+        "properties": {
+          "newIban": {
+            "type": "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse" : {
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
+      "UpdateTransferIbanMassiveResponse": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
           },
-          "updatedTransfers" : {
-            "type" : "integer",
-            "format" : "int32"
+          "updatedTransfers": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentsWithDebtorInfoModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "payStandIn" : {
-            "type" : "boolean"
+          "payStandIn": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "serviceType" : {
-            "type" : "string"
+          "serviceType": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "iupd" : {
-            "type" : "string"
+          "iupd": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "fiscalCode" : {
-            "type" : "string"
+          "fiscalCode": {
+            "type": "string"
           },
-          "fullName" : {
-            "type" : "string"
+          "fullName": {
+            "type": "string"
           },
-          "streetName" : {
-            "type" : "string"
+          "streetName": {
+            "type": "string"
           },
-          "civicNumber" : {
-            "type" : "string"
+          "civicNumber": {
+            "type": "string"
           },
-          "postalCode" : {
-            "type" : "string"
+          "postalCode": {
+            "type": "string"
           },
-          "city" : {
-            "type" : "string"
+          "city": {
+            "type": "string"
           },
-          "province" : {
-            "type" : "string"
+          "province": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "country" : {
-            "type" : "string"
+          "country": {
+            "type": "string"
           },
-          "email" : {
-            "type" : "string"
+          "email": {
+            "type": "string"
           },
-          "phone" : {
-            "type" : "string"
+          "phone": {
+            "type": "string"
           },
-          "companyName" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "officeName" : {
-            "type" : "string"
+          "officeName": {
+            "type": "string"
           },
-          "debtPositionStatus" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          "debtPositionStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "PaymentOptionModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
-          },
-          "iuv" : {
-            "type" : "string"
-          },
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "isPartialPayment" : {
-            "type" : "boolean"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentMethod" : {
-            "type" : "string"
-          },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "pspCompany" : {
-            "type" : "string"
-          },
-          "idReceipt" : {
-            "type" : "string"
-          },
-          "idFlowReporting" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
-            }
-          },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse" : {
-        "type" : "object",
-        "properties" : {
-          "iupd" : {
-            "type" : "string"
+      "PaymentOptionModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "companyName" : {
-            "type" : "string"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "officeName" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "publishDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "validityDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOption" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+            }
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "Page number",
-            "format" : "int32"
+      "PaymentPositionModelBaseResponse": {
+        "type": "object",
+        "properties": {
+          "iupd": {
+            "type": "string"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "Required number of items per page",
-            "format" : "int32"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "Number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "Total number of pages",
-            "format" : "int32"
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validityDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+            }
           }
         }
       },
-      "PaymentPositionsInfo" : {
-        "required" : [ "page_info", "payment_position_list" ],
-        "type" : "object",
-        "properties" : {
-          "payment_position_list" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "Page number",
+            "format": "int32"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Required number of items per page",
+            "format": "int32"
+          },
+          "items_found": {
+            "type": "integer",
+            "description": "Number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages",
+            "format": "int32"
+          }
+        }
+      },
+      "PaymentPositionsInfo": {
+        "required": [
+          "page_info",
+          "payment_position_list"
+        ],
+        "type": "object",
+        "properties": {
+          "payment_position_list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       },
-      "MultipleIUPDModel" : {
-        "required" : [ "paymentPositionIUPDs" ],
-        "type" : "object",
-        "properties" : {
-          "paymentPositionIUPDs" : {
-            "maxItems" : 20,
-            "minItems" : 0,
-            "type" : "array",
-            "items" : {
-              "type" : "string"
+      "MultipleIUPDModel": {
+        "required": [
+          "paymentPositionIUPDs"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentPositionIUPDs": {
+            "maxItems": 20,
+            "minItems": 0,
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_internal_v2.json
+++ b/openapi/openapi_internal_v2.json
@@ -1,3481 +1,3213 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/gpd/api/v2",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/gpd/api/v2",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/gpd/api/v2",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/gpd/api/v2",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/internal/config/send": {
-      "post": {
-        "tags": [
-          "Configuration"
-        ],
-        "summary": "Configures payment options for which communication with SeND is synchronous",
-        "operationId": "handleSyncSendConfiguration",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "maximum": 1000,
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Notice"
+    "/internal/config/send" : {
+      "post" : {
+        "tags" : [ "Configuration" ],
+        "summary" : "Configures payment options for which communication with SeND is synchronous",
+        "operationId" : "handleSyncSendConfiguration",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "maximum" : 1000,
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/Notice"
                 }
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
-        "operationId": "getOrganizationDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of elements on one page. Default = 50",
-            "required": false,
-            "schema": {
-              "maximum": 50,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number. Page value starts from 0",
-            "required": false,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "due_date_from",
-            "in": "query",
-            "description": "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "due_date_to",
-            "in": "query",
-            "description": "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_from",
-            "in": "query",
-            "description": "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "payment_date_to",
-            "in": "query",
-            "description": "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Filter by debt position status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "DRAFT",
-                "PUBLISHED",
-                "VALID",
-                "INVALID",
-                "EXPIRED",
-                "PARTIALLY_PAID",
-                "PAID",
-                "REPORTED"
-              ]
-            }
-          },
-          {
-            "name": "orderby",
-            "in": "query",
-            "description": "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "INSERTED_DATE",
-              "enum": [
-                "INSERTED_DATE",
-                "IUPD",
-                "STATUS",
-                "COMPANY_NAME"
-              ]
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "Direction of ordering",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "DESC",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the list of the organization debt positions. The due dates interval is mutually exclusive with the payment dates interval.",
+        "operationId" : "getOrganizationDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained all organization payment positions.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of elements on one page. Default = 50",
+          "required" : false,
+          "schema" : {
+            "maximum" : 50,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Page number. Page value starts from 0",
+          "required" : false,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "due_date_from",
+          "in" : "query",
+          "description" : "Filter from due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the due_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "due_date_to",
+          "in" : "query",
+          "description" : "Filter to due_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the due_date_from.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_from",
+          "in" : "query",
+          "description" : "Filter from payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days before the payment_date_to.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "payment_date_to",
+          "in" : "query",
+          "description" : "Filter to payment_date (if provided use the format yyyy-MM-dd). If not provided will be set to 30 days after the payment_date_from",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "format" : "date"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "Filter by debt position status",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          }
+        }, {
+          "name" : "orderby",
+          "in" : "query",
+          "description" : "Order by INSERTED_DATE, COMPANY_NAME, IUPD or STATUS",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "INSERTED_DATE",
+            "enum" : [ "INSERTED_DATE", "IUPD", "STATUS", "COMPANY_NAME" ]
+          }
+        }, {
+          "name" : "ordering",
+          "in" : "query",
+          "description" : "Direction of ordering",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "DESC",
+            "enum" : [ "ASC", "DESC" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained all organization payment positions.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionsInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionsInfo"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates multiple debt positions.",
-        "operationId": "updateMultiplePositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates multiple debt positions.",
+        "operationId" : "updateMultiplePositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Positions updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization creates multiple debt positions.",
-        "operationId": "createMultiplePositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates multiple debt positions.",
+        "operationId" : "createMultiplePositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultiplePaymentPositionModel"
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Request created.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: duplicate debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes multiple debt positions.",
-        "operationId": "deleteMultipleDebtPositions",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\b\\w{11}\\b",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes multiple debt positions.",
+        "operationId" : "deleteMultipleDebtPositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\b\\w{11}\\b",
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MultipleIUPDModel"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultipleIUPDModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Positions deleted.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions deleted.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Payment Position not found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
+                }
+              }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Payment Position not found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : { }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/transfers": {
-      "patch": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates the IBANs of every updatable payment option's transfers",
-        "operationId": "updateTransferIbanMassive",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "oldIban",
-            "in": "query",
-            "description": "The old iban to replace",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of Transfer to update (max = 1000, default = 1000)",
-            "required": false,
-            "schema": {
-              "maximum": 1000,
-              "type": "integer",
-              "format": "int32",
-              "default": 1000
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/transfers" : {
+      "patch" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates the IBANs of every updatable payment option's transfers",
+        "operationId" : "updateTransferIbanMassive",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTransferIbanMassiveModel"
+        }, {
+          "name" : "oldIban",
+          "in" : "query",
+          "description" : "The old iban to replace",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Number of Transfer to update (max = 1000, default = 1000)",
+          "required" : false,
+          "schema" : {
+            "maximum" : 1000,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 1000
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateTransferIbanMassiveModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "IBANs updated",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "IBANs updated",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateTransferIbanMassiveResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UpdateTransferIbanMassiveResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "Return the details of a specific debt position.",
-        "operationId": "getOrganizationDebtPositionByIUPD",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "Return the details of a specific debt position.",
+        "operationId" : "getOrganizationDebtPositionByIUPD",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained debt position details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained debt position details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization updates a debt position ",
-        "operationId": "updatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toPublish",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+      "put" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization updates a debt position ",
+        "operationId" : "updatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PaymentPositionModel"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PaymentPositionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Debt Position updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Debt Position updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The Organization deletes a debt position",
-        "operationId": "deletePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "pattern": "[\\w*\\h-]+",
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization deletes a debt position",
+        "operationId" : "deletePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operation completed successfully.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "[\\w*\\h-]+",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Operation completed successfully.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization invalidate a debt Position.",
-        "operationId": "invalidatePosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/invalidate" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization invalidate a debt Position.",
+        "operationId" : "invalidatePosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in invalidable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in invalidable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish": {
-      "post": {
-        "tags": [
-          "Debt Position Actions API"
-        ],
-        "summary": "The Organization publish a debt Position.",
-        "operationId": "publishPosition",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iupd",
-            "in": "path",
-            "description": "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/debtpositions/{iupd}/publish" : {
+      "post" : {
+        "tags" : [ "Debt Position Actions API" ],
+        "summary" : "The Organization publish a debt Position.",
+        "operationId" : "publishPosition",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request published.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iupd",
+          "in" : "path",
+          "description" : "IUPD (Unique identifier of the debt position). Format could be `<Organization fiscal code + UUID>` this would make it unique within the new PD management system. It's the responsibility of the EC to guarantee uniqueness. The pagoPa system shall verify that this is `true` and if not, notify the EC.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request published.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModel"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModel"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "No debt position found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: debt position is not in publishable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: debt position is not in publishable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition": {
-      "get": {
-        "tags": [
-          "Debt Positions API"
-        ],
-        "summary": "The organization retrieves a debt position by payment option IUV",
-        "operationId": "getDebtPositionByIUV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\d{11}",
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "Payment Option IUV",
-            "required": true,
-            "schema": {
-              "pattern": "\\b\\w{0,35}\\b",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/debtposition" : {
+      "get" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The organization retrieves a debt position by payment option IUV",
+        "operationId" : "getDebtPositionByIUV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\d{11}",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Debt Positions updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "Payment Option IUV",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\b\\w{0,35}\\b",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Debt Positions updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "example": {
-                  "statusCode": 403,
-                  "message": "You are not allowed to access this resource."
+            "content" : {
+              "application/json" : {
+                "example" : {
+                  "statusCode" : 403,
+                  "message" : "You are not allowed to access this resource."
                 }
               }
             }
           },
-          "404": {
-            "description": "Payment Position not found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Payment Position not found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "429": {
-            "description": "Too many requests.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization reports a transaction.",
-        "operationId": "reportTransfer",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "iuv",
-            "in": "path",
-            "description": "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "transferid",
-            "in": "path",
-            "description": "Transaction identifier. Alphanumeric code that identifies the specific transaction",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{iuv}/transfers/{transferid}/report" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization reports a transaction.",
+        "operationId" : "reportTransfer",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Request reported.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "iuv",
+          "in" : "path",
+          "description" : "IUV (Unique Payment Identification). Alphanumeric code that uniquely associates and identifies three key elements of a payment: reason, payer, amount",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "transferid",
+          "in" : "path",
+          "description" : "Transaction identifier. Alphanumeric code that identifies the specific transaction",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Request reported.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TransferModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransferModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No transfer found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No transfer found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
-      "get": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "Return the details of a specific payment option.",
-        "operationId": "getOrganizationPaymentOptionByNAV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\d{1,30}",
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "pattern": "^\\d{1,30}$",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
+      "get" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "Return the details of a specific payment option.",
+        "operationId" : "getOrganizationPaymentOptionByNAV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\d{1,30}",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained payment option details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "^\\d{1,30}$",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained payment option details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
-      "put": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization updates the notification fee of a payment option.",
-        "operationId": "updateNotificationFee",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
+      "put" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization updates the notification fee of a payment option.",
+        "operationId" : "updateNotificationFee",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Request updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Request updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "209": {
-            "description": "Request updated with a payment in progress.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "209" : {
+            "description" : "Request updated with a payment in progress.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable payment option.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "422" : {
+            "description" : "Unprocessable payment option.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay": {
-      "post": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The Organization paid a payment option.",
-        "operationId": "payPaymentOption",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/pay" : {
+      "post" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The Organization paid a payment option.",
+        "operationId" : "payPaymentOption",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PayPaymentOptionModel"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PayPaymentOptionModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Request paid.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Request paid.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict: existing related payment found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict: existing related payment found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable: not in payable state.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "422" : {
+            "description" : "Unprocessable: not in payable state.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "NotificationFeeUpdateModel": {
-        "required": [
-          "notificationFee"
-        ],
-        "type": "object",
-        "properties": {
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+  "components" : {
+    "schemas" : {
+      "NotificationFeeUpdateModel" : {
+        "required" : [ "notificationFee" ],
+        "type" : "object",
+        "properties" : {
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentsModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "lastUpdatedDateNotificationFee": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDateNotificationFee" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "MultiplePaymentPositionModel": {
-        "required": [
-          "paymentPositions"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentPositions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModel"
+      "MultiplePaymentPositionModel" : {
+        "required" : [ "paymentPositions" ],
+        "type" : "object",
+        "properties" : {
+          "paymentPositions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModel"
             }
           }
         }
       },
-      "PaymentOptionMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "PaymentOptionModel": {
-        "required": [
-          "amount",
-          "description",
-          "dueDate",
-          "isPartialPayment",
-          "iuv"
-        ],
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "description", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "description" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64",
-            "readOnly": true
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModel"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
             }
           },
-          "paymentOptionMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModel"
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
             }
           }
         }
       },
-      "PaymentPositionModel": {
-        "required": [
-          "companyName",
-          "fiscalCode",
-          "fullName",
-          "iupd",
-          "switchToExpired",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "switchToExpired", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "payStandIn": {
-            "type": "boolean",
-            "description": "feature flag to enable a debt position in stand-in mode",
-            "example": true,
-            "default": true
+          "payStandIn" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable a debt position in stand-in mode",
+            "example" : true,
+            "default" : true
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "example": "IT"
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "example" : "IT"
           },
-          "email": {
-            "type": "string",
-            "example": "email@domain.com"
+          "email" : {
+            "type" : "string",
+            "example" : "email@domain.com"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "switchToExpired": {
-            "type": "boolean",
-            "description": "feature flag to enable the debt position to expire after the due date",
-            "example": false,
-            "default": false
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "officeName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "officeName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
           },
-          "status": {
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModel"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
             }
           }
         }
       },
-      "TransferMetadataModel": {
-        "required": [
-          "key"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         },
-        "description": "it can added a maximum of 10 key-value pairs for metadata"
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
       },
-      "TransferModel": {
-        "required": [
-          "amount",
-          "category",
-          "idTransfer",
-          "remittanceInformation"
-        ],
-        "type": "object",
-        "properties": {
-          "idTransfer": {
-            "type": "string",
-            "enum": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ]
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "organizationFiscalCode": {
-            "type": "string",
-            "description": "Fiscal code related to the organization targeted by this transfer.",
-            "example": "00000000000"
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
           },
-          "remittanceInformation": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "remittanceInformation" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string",
-            "description": "mutual exclusive with stamp",
-            "example": "IT0000000000000000000000000"
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "postalIban": {
-            "type": "string",
-            "description": "optional - can be combined with iban but not with stamp",
-            "example": "IT0000000000000000000000000"
+          "postalIban" : {
+            "type" : "string",
+            "description" : "optional - can be combined with iban but not with stamp",
+            "example" : "IT0000000000000000000000000"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "companyName": {
-            "maxLength": 140,
-            "minLength": 0,
-            "type": "string"
+          "companyName" : {
+            "maxLength" : 140,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "transferMetadata": {
-            "maxItems": 10,
-            "minItems": 0,
-            "type": "array",
-            "description": "it can added a maximum of 10 key-value pairs for metadata",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModel"
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
             }
           }
         }
       },
-      "PayPaymentOptionModel": {
-        "required": [
-          "idReceipt",
-          "pspCompany"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+      "PayPaymentOptionModel" : {
+        "required" : [ "idReceipt", "pspCompany" ],
+        "type" : "object",
+        "properties" : {
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "pspCode": {
-            "type": "string"
+          "pspCode" : {
+            "maxLength" : 35,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "pspTaxCode": {
-            "type": "string"
+          "pspTaxCode" : {
+            "maxLength" : 70,
+            "minLength" : 0,
+            "type" : "string"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "string"
+          "fee" : {
+            "type" : "string"
           }
         }
       },
-      "Notice": {
-        "required": [
-          "nav",
-          "organizationFiscalCode"
-        ],
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "Notice" : {
+        "required" : [ "nav", "organizationFiscalCode" ],
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "nav": {
-            "type": "string"
+          "nav" : {
+            "type" : "string"
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveModel": {
-        "required": [
-          "newIban"
-        ],
-        "type": "object",
-        "properties": {
-          "newIban": {
-            "type": "string"
+      "UpdateTransferIbanMassiveModel" : {
+        "required" : [ "newIban" ],
+        "type" : "object",
+        "properties" : {
+          "newIban" : {
+            "type" : "string"
           }
         }
       },
-      "UpdateTransferIbanMassiveResponse": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
+      "UpdateTransferIbanMassiveResponse" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
           },
-          "updatedTransfers": {
-            "type": "integer",
-            "format": "int32"
+          "updatedTransfers" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsWithDebtorInfoModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "payStandIn" : {
+            "type" : "boolean"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "idReceipt": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          },
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "iupd": {
-            "type": "string"
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "type": "string"
+          "country" : {
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "debtPositionStatus": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "debtPositionStatus" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentOptionModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentOptionModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentPositionModelBaseResponse": {
-        "type": "object",
-        "properties": {
-          "iupd": {
-            "type": "string"
+      "PaymentPositionModelBaseResponse" : {
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "publishDate": {
-            "type": "string",
-            "format": "date-time"
+          "publishDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "validityDate": {
-            "type": "string",
-            "format": "date-time"
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOption": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionModelResponse"
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModelResponse"
             }
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         }
       },
-      "PaymentPositionsInfo": {
-        "required": [
-          "page_info",
-          "payment_position_list"
-        ],
-        "type": "object",
-        "properties": {
-          "payment_position_list": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentPositionModelBaseResponse"
+      "PaymentPositionsInfo" : {
+        "required" : [ "page_info", "payment_position_list" ],
+        "type" : "object",
+        "properties" : {
+          "payment_position_list" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModelBaseResponse"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "MultipleIUPDModel": {
-        "required": [
-          "paymentPositionIUPDs"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentPositionIUPDs": {
-            "maxItems": 20,
-            "minItems": 0,
-            "type": "array",
-            "items": {
-              "type": "string"
+      "MultipleIUPDModel" : {
+        "required" : [ "paymentPositionIUPDs" ],
+        "type" : "object",
+        "properties" : {
+          "paymentPositionIUPDs" : {
+            "maxItems" : 20,
+            "minItems" : 0,
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_internal_v2.json
+++ b/openapi/openapi_internal_v2.json
@@ -2943,6 +2943,9 @@
           "idFlowReporting" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
           "status" : {
             "type" : "string",
             "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]

--- a/openapi/openapi_send_v1.json
+++ b/openapi/openapi_send_v1.json
@@ -1,796 +1,741 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "PagoPA API Debt Position ${service}",
-    "description": "Progetto Gestione Posizioni Debitorie",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.14.4"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position ${service}",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.14.4"
   },
-  "servers": [
-    {
-      "url": "https://api.uat.platform.pagopa.it/pn-integration-gpd/api/v1",
-      "description": "GPD Test environment"
-    },
-    {
-      "url": "https://api.platform.pagopa.it/pn-integration-gpd/api/v1",
-      "description": "GPD Production Environment"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "https://api.uat.platform.pagopa.it/pn-integration-gpd/api/v1",
+    "description" : "GPD Test environment"
+  }, {
+    "url" : "https://api.platform.pagopa.it/pn-integration-gpd/api/v1",
+    "description" : "GPD Production Environment"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
-      "get": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "Return the details of a specific payment option.",
-        "operationId": "getOrganizationPaymentOptionByNAV",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "pattern": "\\d{1,30}",
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "pattern": "^\\d{1,30}$",
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
+      "get" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "Return the details of a specific payment option.",
+        "operationId" : "getOrganizationPaymentOptionByNAV",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "\\d{1,30}",
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Obtained payment option details.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "pattern" : "^\\d{1,30}$",
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Obtained payment option details.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
-      "put": {
-        "tags": [
-          "Payments API"
-        ],
-        "summary": "The organization updates the notification fee of a payment option.",
-        "operationId": "updateNotificationFee",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "Organization fiscal code, the fiscal code of the Organization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
+      "put" : {
+        "tags" : [ "Payments API" ],
+        "summary" : "The organization updates the notification fee of a payment option.",
+        "operationId" : "updateNotificationFee",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "Request updated.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "Request updated.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "209": {
-            "description": "Request updated with a payment in progress.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "209" : {
+            "description" : "Request updated with a payment in progress.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentsModelResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaymentsModelResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Malformed request.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "No payment option found.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "No payment option found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable payment option.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "422" : {
+            "description" : "Unprocessable payment option.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "NotificationFeeUpdateModel": {
-        "required": [
-          "notificationFee"
-        ],
-        "type": "object",
-        "properties": {
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+  "components" : {
+    "schemas" : {
+      "NotificationFeeUpdateModel" : {
+        "required" : [ "notificationFee" ],
+        "type" : "object",
+        "properties" : {
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "PaymentOptionMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "PaymentsModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idReceipt": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "lastUpdatedDateNotificationFee": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDateNotificationFee" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "Stamp": {
-        "required": [
-          "hashDocument",
-          "provincialResidence",
-          "stampType"
-        ],
-        "type": "object",
-        "properties": {
-          "hashDocument": {
-            "maxLength": 72,
-            "minLength": 0,
-            "type": "string",
-            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "maxLength" : 72,
+            "minLength" : 0,
+            "type" : "string",
+            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "stampType": {
-            "maxLength": 2,
-            "minLength": 2,
-            "type": "string",
-            "description": "The type of the stamp"
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
           },
-          "provincialResidence": {
-            "pattern": "[A-Z]{2}",
-            "type": "string",
-            "description": "The provincial of the residence",
-            "example": "RM"
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
           }
         }
       },
-      "TransferMetadataModelResponse": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string"
+      "TransferMetadataModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "TransferModelResponse": {
-        "type": "object",
-        "properties": {
-          "organizationFiscalCode": {
-            "type": "string"
+      "TransferModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "idTransfer": {
-            "type": "string"
+          "idTransfer" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "remittanceInformation": {
-            "type": "string"
+          "remittanceInformation" : {
+            "type" : "string"
           },
-          "category": {
-            "type": "string"
+          "category" : {
+            "type" : "string"
           },
-          "iban": {
-            "type": "string"
+          "iban" : {
+            "type" : "string"
           },
-          "postalIban": {
-            "type": "string"
+          "postalIban" : {
+            "type" : "string"
           },
-          "stamp": {
-            "$ref": "#/components/schemas/Stamp"
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "T_UNREPORTED",
-              "T_REPORTED"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
           },
-          "lastUpdatedDate": {
-            "type": "string",
-            "format": "date-time"
+          "lastUpdatedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "transferMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferMetadataModelResponse"
+          "transferMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse": {
-        "type": "object",
-        "properties": {
-          "nav": {
-            "type": "string"
+      "PaymentsWithDebtorInfoModelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string"
           },
-          "iuv": {
-            "type": "string"
+          "iuv" : {
+            "type" : "string"
           },
-          "organizationFiscalCode": {
-            "type": "string"
+          "organizationFiscalCode" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "description": {
-            "type": "string"
+          "description" : {
+            "type" : "string"
           },
-          "isPartialPayment": {
-            "type": "boolean"
+          "isPartialPayment" : {
+            "type" : "boolean"
           },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
+          "payStandIn" : {
+            "type" : "boolean"
           },
-          "retentionDate": {
-            "type": "string",
-            "format": "date-time"
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentDate": {
-            "type": "string",
-            "format": "date-time"
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "reportingDate": {
-            "type": "string",
-            "format": "date-time"
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "insertedDate": {
-            "type": "string",
-            "format": "date-time"
+          "reportingDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "paymentMethod": {
-            "type": "string"
+          "insertedDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "fee": {
-            "type": "integer",
-            "format": "int64"
+          "paymentMethod" : {
+            "type" : "string"
           },
-          "notificationFee": {
-            "type": "integer",
-            "format": "int64"
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "pspCompany": {
-            "type": "string"
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "idReceipt": {
-            "type": "string"
+          "pspCompany" : {
+            "type" : "string"
           },
-          "idFlowReporting": {
-            "type": "string"
+          "idReceipt" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PO_UNPAID",
-              "PO_PAID",
-              "PO_PARTIALLY_REPORTED",
-              "PO_REPORTED"
-            ]
+          "idFlowReporting" : {
+            "type" : "string"
           },
-          "paymentOptionMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          },
+          "paymentOptionMetadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "iupd": {
-            "type": "string"
+          "iupd" : {
+            "type" : "string"
           },
-          "type": {
-            "type": "string",
-            "enum": [
-              "F",
-              "G"
-            ]
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "fullName": {
-            "type": "string"
+          "fullName" : {
+            "type" : "string"
           },
-          "streetName": {
-            "type": "string"
+          "streetName" : {
+            "type" : "string"
           },
-          "civicNumber": {
-            "type": "string"
+          "civicNumber" : {
+            "type" : "string"
           },
-          "postalCode": {
-            "type": "string"
+          "postalCode" : {
+            "type" : "string"
           },
-          "city": {
-            "type": "string"
+          "city" : {
+            "type" : "string"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "region": {
-            "type": "string"
+          "region" : {
+            "type" : "string"
           },
-          "country": {
-            "type": "string"
+          "country" : {
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "phone": {
-            "type": "string"
+          "phone" : {
+            "type" : "string"
           },
-          "companyName": {
-            "type": "string"
+          "companyName" : {
+            "type" : "string"
           },
-          "officeName": {
-            "type": "string"
+          "officeName" : {
+            "type" : "string"
           },
-          "debtPositionStatus": {
-            "type": "string",
-            "enum": [
-              "DRAFT",
-              "PUBLISHED",
-              "VALID",
-              "INVALID",
-              "EXPIRED",
-              "PARTIALLY_PAID",
-              "PAID",
-              "REPORTED"
-            ]
+          "debtPositionStatus" : {
+            "type" : "string",
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
           },
-          "transfer": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TransferModelResponse"
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_send_v1.json
+++ b/openapi/openapi_send_v1.json
@@ -1,744 +1,802 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "PagoPA API Debt Position ${service}",
-    "description" : "Progetto Gestione Posizioni Debitorie",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.14.4"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PagoPA API Debt Position ${service}",
+    "description": "Progetto Gestione Posizioni Debitorie",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.14.5-PAGOPA-3108"
   },
-  "servers" : [ {
-    "url" : "https://api.uat.platform.pagopa.it/pn-integration-gpd/api/v1",
-    "description" : "GPD Test environment"
-  }, {
-    "url" : "https://api.platform.pagopa.it/pn-integration-gpd/api/v1",
-    "description" : "GPD Production Environment"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
-      },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
-        }
-      } ]
+  "servers": [
+    {
+      "url": "https://api.uat.platform.pagopa.it/pn-integration-gpd/api/v1",
+      "description": "GPD Test environment"
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}" : {
-      "get" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "Return the details of a specific payment option.",
-        "operationId" : "getOrganizationPaymentOptionByNAV",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "\\d{1,30}",
-            "type" : "string"
-          }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "pattern" : "^\\d{1,30}$",
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Obtained payment option details.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+    {
+      "url": "https://api.platform.pagopa.it/pn-integration-gpd/api/v1",
+      "description": "GPD Production Environment"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "403": {
+            "description": "Forbidden.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee" : {
-      "put" : {
-        "tags" : [ "Payments API" ],
-        "summary" : "The organization updates the notification fee of a payment option.",
-        "operationId" : "updateNotificationFee",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "Organization fiscal code, the fiscal code of the Organization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}": {
+      "get": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "Return the details of a specific payment option.",
+        "operationId": "getOrganizationPaymentOptionByNAV",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "pattern": "\\d{1,30}",
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "pattern": "^\\d{1,30}$",
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "description" : "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/NotificationFeeUpdateModel"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Request updated.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "Obtained payment option details.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsWithDebtorInfoModelResponse"
                 }
               }
             }
           },
-          "209" : {
-            "description" : "Request updated with a payment in progress.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PaymentsModelResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Malformed request.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Wrong or missing function key.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "No payment option found.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "422" : {
-            "description" : "Unprocessable payment option.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable.",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
+    },
+    "/organizations/{organizationfiscalcode}/paymentoptions/{nav}/notificationfee": {
+      "put": {
+        "tags": [
+          "Payments API"
+        ],
+        "summary": "The organization updates the notification fee of a payment option.",
+        "operationId": "updateNotificationFee",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "Organization fiscal code, the fiscal code of the Organization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "description": "NAV (notice number) is the unique reference assigned to the payment by a creditor institution.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationFeeUpdateModel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Request updated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "209": {
+            "description": "Request updated with a payment in progress.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsModelResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No payment option found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable payment option.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "NotificationFeeUpdateModel" : {
-        "required" : [ "notificationFee" ],
-        "type" : "object",
-        "properties" : {
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+  "components": {
+    "schemas": {
+      "NotificationFeeUpdateModel": {
+        "required": [
+          "notificationFee"
+        ],
+        "type": "object",
+        "properties": {
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "PaymentOptionMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "PaymentOptionMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         }
       },
-      "PaymentsModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "PaymentsModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "iuv" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "isPartialPayment": {
+            "type": "boolean"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "paymentMethod": {
+            "type": "string"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "fee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
           },
-          "pspCompany" : {
-            "type" : "string"
+          "pspCompany": {
+            "type": "string"
           },
-          "idReceipt" : {
-            "type" : "string"
+          "idReceipt": {
+            "type": "string"
           },
-          "idFlowReporting" : {
-            "type" : "string"
+          "idFlowReporting": {
+            "type": "string"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
           },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "lastUpdatedDateNotificationFee" : {
-            "type" : "string",
-            "format" : "date-time"
+          "lastUpdatedDateNotificationFee": {
+            "type": "string",
+            "format": "date-time"
           },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
             }
           },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
-            }
-          }
-        }
-      },
-      "Stamp" : {
-        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
-        "type" : "object",
-        "properties" : {
-          "hashDocument" : {
-            "maxLength" : 72,
-            "minLength" : 0,
-            "type" : "string",
-            "description" : "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
-          },
-          "stampType" : {
-            "maxLength" : 2,
-            "minLength" : 2,
-            "type" : "string",
-            "description" : "The type of the stamp"
-          },
-          "provincialResidence" : {
-            "pattern" : "[A-Z]{2}",
-            "type" : "string",
-            "description" : "The provincial of the residence",
-            "example" : "RM"
-          }
-        }
-      },
-      "TransferMetadataModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      },
-      "TransferModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "organizationFiscalCode" : {
-            "type" : "string"
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "idTransfer" : {
-            "type" : "string"
-          },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "remittanceInformation" : {
-            "type" : "string"
-          },
-          "category" : {
-            "type" : "string"
-          },
-          "iban" : {
-            "type" : "string"
-          },
-          "postalIban" : {
-            "type" : "string"
-          },
-          "stamp" : {
-            "$ref" : "#/components/schemas/Stamp"
-          },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "T_UNREPORTED", "T_REPORTED" ]
-          },
-          "lastUpdatedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "transferMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferMetadataModelResponse"
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
             }
           }
         }
       },
-      "PaymentsWithDebtorInfoModelResponse" : {
-        "type" : "object",
-        "properties" : {
-          "nav" : {
-            "type" : "string"
+      "Stamp": {
+        "required": [
+          "hashDocument",
+          "provincialResidence",
+          "stampType"
+        ],
+        "type": "object",
+        "properties": {
+          "hashDocument": {
+            "maxLength": 72,
+            "minLength": 0,
+            "type": "string",
+            "description": "Document hash type is stBase64Binary72 as described in https://github.com/pagopa/pagopa-api."
           },
-          "iuv" : {
-            "type" : "string"
+          "stampType": {
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string",
+            "description": "The type of the stamp"
           },
-          "organizationFiscalCode" : {
-            "type" : "string"
+          "provincialResidence": {
+            "pattern": "[A-Z]{2}",
+            "type": "string",
+            "description": "The provincial of the residence",
+            "example": "RM"
+          }
+        }
+      },
+      "TransferMetadataModelResponse": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferModelResponse": {
+        "type": "object",
+        "properties": {
+          "organizationFiscalCode": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "companyName": {
+            "type": "string"
           },
-          "isPartialPayment" : {
-            "type" : "boolean"
+          "idTransfer": {
+            "type": "string"
           },
-          "payStandIn" : {
-            "type" : "boolean"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "remittanceInformation": {
+            "type": "string"
           },
-          "retentionDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "category": {
+            "type": "string"
           },
-          "paymentDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "iban": {
+            "type": "string"
           },
-          "reportingDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "postalIban": {
+            "type": "string"
           },
-          "insertedDate" : {
-            "type" : "string",
-            "format" : "date-time"
+          "stamp": {
+            "$ref": "#/components/schemas/Stamp"
           },
-          "paymentMethod" : {
-            "type" : "string"
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "fee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "status": {
+            "type": "string",
+            "enum": [
+              "T_UNREPORTED",
+              "T_REPORTED"
+            ]
           },
-          "notificationFee" : {
-            "type" : "integer",
-            "format" : "int64"
+          "lastUpdatedDate": {
+            "type": "string",
+            "format": "date-time"
           },
-          "pspCompany" : {
-            "type" : "string"
-          },
-          "idReceipt" : {
-            "type" : "string"
-          },
-          "idFlowReporting" : {
-            "type" : "string"
-          },
-          "serviceType" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]
-          },
-          "paymentOptionMetadata" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentOptionMetadataModelResponse"
-            }
-          },
-          "iupd" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "F", "G" ]
-          },
-          "fiscalCode" : {
-            "type" : "string"
-          },
-          "fullName" : {
-            "type" : "string"
-          },
-          "streetName" : {
-            "type" : "string"
-          },
-          "civicNumber" : {
-            "type" : "string"
-          },
-          "postalCode" : {
-            "type" : "string"
-          },
-          "city" : {
-            "type" : "string"
-          },
-          "province" : {
-            "type" : "string"
-          },
-          "region" : {
-            "type" : "string"
-          },
-          "country" : {
-            "type" : "string"
-          },
-          "email" : {
-            "type" : "string"
-          },
-          "phone" : {
-            "type" : "string"
-          },
-          "companyName" : {
-            "type" : "string"
-          },
-          "officeName" : {
-            "type" : "string"
-          },
-          "debtPositionStatus" : {
-            "type" : "string",
-            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
-          },
-          "transfer" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TransferModelResponse"
+          "transferMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferMetadataModelResponse"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "PaymentsWithDebtorInfoModelResponse": {
+        "type": "object",
+        "properties": {
+          "nav": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "iuv": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "organizationFiscalCode": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isPartialPayment": {
+            "type": "boolean"
+          },
+          "payStandIn": {
+            "type": "boolean"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "retentionDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reportingDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "insertedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paymentMethod": {
+            "type": "string"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "notificationFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "pspCompany": {
+            "type": "string"
+          },
+          "idReceipt": {
+            "type": "string"
+          },
+          "idFlowReporting": {
+            "type": "string"
+          },
+          "serviceType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PO_UNPAID",
+              "PO_PAID",
+              "PO_PARTIALLY_REPORTED",
+              "PO_REPORTED"
+            ]
+          },
+          "paymentOptionMetadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentOptionMetadataModelResponse"
+            }
+          },
+          "iupd": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "F",
+              "G"
+            ]
+          },
+          "fiscalCode": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "streetName": {
+            "type": "string"
+          },
+          "civicNumber": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "officeName": {
+            "type": "string"
+          },
+          "debtPositionStatus": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "PUBLISHED",
+              "VALID",
+              "INVALID",
+              "EXPIRED",
+              "PARTIALLY_PAID",
+              "PAID",
+              "REPORTED"
+            ]
+          },
+          "transfer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferModelResponse"
+            }
+          }
+        }
+      },
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "environment": {
+            "type": "string"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_send_v1.json
+++ b/openapi/openapi_send_v1.json
@@ -647,6 +647,9 @@
           "idFlowReporting" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
           "status" : {
             "type" : "string",
             "enum" : [ "PO_UNPAID", "PO_PAID", "PO_PARTIALLY_REPORTED", "PO_REPORTED" ]

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>it.gov.pagopa.debtposition</groupId>
     <artifactId>gpd</artifactId>
-    <version>0.14.4</version>
+    <version>0.14.5-PAGOPA-3108</version>
     <name>Gestione Posizioni Debitorie</name>
     <description>Progetto Gestione Posizioni Debitorie</description>
     <properties>

--- a/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
+++ b/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
@@ -51,6 +51,7 @@ public class ConvertPOEntityToPOWithDebtor
     destination.setCompanyName(source.getPaymentPosition().getCompanyName());
     destination.setOfficeName(source.getPaymentPosition().getOfficeName());
     destination.setPayStandIn(source.getPaymentPosition().getPayStandIn());
+    destination.setServiceType(source.getPaymentPosition().getServiceType().name());
 
     // Get Debtor fields from Payment Position since is UNDEFINED on Payment Option
     String poFullName = source.getFullName();

--- a/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
+++ b/src/main/java/it/gov/pagopa/debtposition/mapper/ConvertPOEntityToPOWithDebtor.java
@@ -50,6 +50,7 @@ public class ConvertPOEntityToPOWithDebtor
     destination.setIupd(source.getPaymentPosition().getIupd());
     destination.setCompanyName(source.getPaymentPosition().getCompanyName());
     destination.setOfficeName(source.getPaymentPosition().getOfficeName());
+    destination.setPayStandIn(source.getPaymentPosition().getPayStandIn());
 
     // Get Debtor fields from Payment Position since is UNDEFINED on Payment Option
     String poFullName = source.getFullName();

--- a/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
+++ b/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
@@ -29,6 +29,7 @@ public class PaymentOptionWithDebtorInfoModelResponse implements Serializable {
   private long amount;
   private String description;
   private Boolean isPartialPayment;
+  private Boolean payStandIn;
   private LocalDateTime dueDate;
   private LocalDateTime retentionDate;
   private LocalDateTime paymentDate;

--- a/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
+++ b/src/main/java/it/gov/pagopa/debtposition/model/payments/response/PaymentOptionWithDebtorInfoModelResponse.java
@@ -41,6 +41,7 @@ public class PaymentOptionWithDebtorInfoModelResponse implements Serializable {
   private String pspCompany;
   private String idReceipt;
   private String idFlowReporting;
+  private String serviceType;
   private PaymentOptionStatus status;
   private List<PaymentOptionMetadataModelResponse> paymentOptionMetadata = new ArrayList<>();
 


### PR DESCRIPTION
This PR contains some changes made on model interfaces, used by internal scope, in order to add new information needed for ACA/Stand-In process on GPD-Payments. The PR includes two new fields, named `payStandIn` and `serviceType`, that will be used for check if a debt position can be paid on ACA flow.

#### List of Changes
- Including field `payStandIn` on `PaymentOptionWithDebtorInfoModelResponse`
- Including field `serviceType` on `PaymentOptionWithDebtorInfoModelResponse`

#### Motivation and Context
This change is required in order to expose some fields on internal APIs

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.