### PR TITLE
fix(security): prevent script injection and switch to gh cli

### DIFF
--- a/.github/workflows/update_code.yml
+++ b/.github/workflows/update_code.yml
@@ -22,8 +22,9 @@ jobs:
           token: ${{ secrets.BOT_TOKEN_GITHUB }}
 
       - name: Checkout Pull Request
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout $PR_NUMBER
         env:
+          PR_NUMBER: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1


### PR DESCRIPTION

This PR resolves two issues in the update_code.yml workflow:

**Security Fix**: Direct use of ${{ github.event.issue.number }} has been replaced with an environment variable $PR_NUMBER to prevent Script Injection.
**Modernization**: The deprecated hub command has been replaced with the standard gh tool (GitHub CLI), as hub is not present in recent runners and caused a command not found error.
