### PR TITLE
fix: remap OptimisticLockingFailureException to http error code 409

### DIFF
--- a/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
@@ -15,6 +15,10 @@ public enum AppError {
 		      HttpStatus.INTERNAL_SERVER_ERROR,
 		      "The debt position creation is failed",
 		      "Creation failed for the debt position with Organization Fiscal Code %s"),
+	DEBT_POSITION_CONCURRENT_CREATION_FAILURE(
+			HttpStatus.CONFLICT,
+			"The debt position creation is failed",
+			"Creation failed for the debt position with Organization Fiscal Code %s ->  concurrent modification detected"),
 		  DEBT_POSITION_UPDATE_FAILED(
 		      HttpStatus.INTERNAL_SERVER_ERROR,
 		      "The debt position update is failed",

--- a/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
@@ -17,7 +17,7 @@ public enum AppError {
 		      "Creation failed for the debt position with Organization Fiscal Code %s"),
 	      DEBT_POSITION_CONCURRENT_CREATION_FAILURE(
 			HttpStatus.CONFLICT,
-			"The debt position creation is failed",
+			"The debt position creation is failed - concurrent creation",
 			"Creation failed for the debt position with Organization Fiscal Code %s ->  concurrent modification detected"),
 		  DEBT_POSITION_UPDATE_FAILED(
 		      HttpStatus.INTERNAL_SERVER_ERROR,
@@ -25,7 +25,7 @@ public enum AppError {
 		      "Update failed for the debt position with Organization Fiscal Code %s"),
 	      DEBT_POSITION_CONCURRENT_UPDATE_FAILURE(
 			HttpStatus.CONFLICT,
-			"The debt position update is failed",
+			"The debt position update is failed - concurrent modification",
 			"Update failed for the debt position with Organization Fiscal Code %s ->  concurrent modification detected"),
 		  DEBT_POSITION_DELETE_FAILED(
 		      HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/debtposition/exception/AppError.java
@@ -15,7 +15,7 @@ public enum AppError {
 		      HttpStatus.INTERNAL_SERVER_ERROR,
 		      "The debt position creation is failed",
 		      "Creation failed for the debt position with Organization Fiscal Code %s"),
-	DEBT_POSITION_CONCURRENT_CREATION_FAILURE(
+	      DEBT_POSITION_CONCURRENT_CREATION_FAILURE(
 			HttpStatus.CONFLICT,
 			"The debt position creation is failed",
 			"Creation failed for the debt position with Organization Fiscal Code %s ->  concurrent modification detected"),
@@ -23,6 +23,10 @@ public enum AppError {
 		      HttpStatus.INTERNAL_SERVER_ERROR,
 		      "The debt position update is failed",
 		      "Update failed for the debt position with Organization Fiscal Code %s"),
+	      DEBT_POSITION_CONCURRENT_UPDATE_FAILURE(
+			HttpStatus.CONFLICT,
+			"The debt position update is failed",
+			"Update failed for the debt position with Organization Fiscal Code %s ->  concurrent modification detected"),
 		  DEBT_POSITION_DELETE_FAILED(
 		      HttpStatus.INTERNAL_SERVER_ERROR,
 		      "The debt position delete is failed",

--- a/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -225,7 +225,7 @@ public class PaymentPositionCRUDService {
 	  page = paymentPositionRepository.findAll(specPP, pageable);
 
 	  positions = page.getContent();
-	  ppCount = (positions == null) ? 0 : positions.size();
+	  ppCount = positions.size();
 
 	  // empty page
 	  if (ppCount == 0) {

--- a/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -496,6 +496,12 @@ public class PaymentPositionCRUDService {
             organizationFiscalCode,
             e.getMessage());
       }
+      if(AppError.DEBT_POSITION_CONCURRENT_CREATION_FAILURE.equals(e.getAppError())) {
+        throw new AppException(
+                AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE,
+                organizationFiscalCode,
+                e.getMessage());
+      }
       throw e;
     } catch (DataIntegrityViolationException e) {
       // Handle database constraint violations explicitly.
@@ -504,8 +510,6 @@ public class PaymentPositionCRUDService {
          handleUniqueViolationAppException(constraintViolationException, organizationFiscalCode);
       }
       throw new AppException(AppError.DEBT_POSITION_UPDATE_FAILED, organizationFiscalCode);
-    } catch (OptimisticLockingFailureException e) {
-      throw new AppException(AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE, organizationFiscalCode);
     } catch (Exception e) {
       // Log the entire exception for debugging purposes.
       log.error("Error during debt position update process", e);

--- a/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -42,6 +42,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -99,6 +100,8 @@ public class PaymentPositionCRUDService {
       throw new AppException(AppError.DEBT_POSITION_REQUEST_DATA_ERROR, e.getMessage());
     } catch (AppException appException) {
       throw appException;
+    } catch (OptimisticLockingFailureException e) {
+      throw new AppException(AppError.DEBT_POSITION_CONCURRENT_CREATION_FAILURE, organizationFiscalCode);
     } catch (Exception e) {
       log.error(String.format(ERROR_CREATION_LOG_MSG, e.getMessage()), e);
       throw new AppException(AppError.DEBT_POSITION_CREATION_FAILED, organizationFiscalCode);
@@ -424,6 +427,8 @@ public class PaymentPositionCRUDService {
       throw new AppException(AppError.DEBT_POSITION_REQUEST_DATA_ERROR, e.getMessage());
     } catch (AppException appException) {
       throw appException;
+    } catch (OptimisticLockingFailureException e) {
+      throw new AppException(AppError.DEBT_POSITION_CONCURRENT_CREATION_FAILURE, organizationFiscalCode);
     } catch (Exception e) {
       log.error(String.format(ERROR_CREATION_LOG_MSG, e.getMessage()), e);
       throw new AppException(AppError.DEBT_POSITION_CREATION_FAILED, organizationFiscalCode);

--- a/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
+++ b/src/main/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDService.java
@@ -336,7 +336,9 @@ public class PaymentPositionCRUDService {
     	    handleUniqueViolationAppException(constraintViolationException, organizationFiscalCode);
       }
       throw new AppException(AppError.DEBT_POSITION_UPDATE_FAILED, organizationFiscalCode);
-    } catch (Exception e) {
+    } catch (OptimisticLockingFailureException e) {
+      throw new AppException(AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE, organizationFiscalCode);
+    }  catch (Exception e) {
       log.error(String.format(ERROR_UPDATE_LOG_MSG, e.getMessage()), e);
       throw new AppException(AppError.DEBT_POSITION_UPDATE_FAILED, organizationFiscalCode);
     }
@@ -502,6 +504,8 @@ public class PaymentPositionCRUDService {
          handleUniqueViolationAppException(constraintViolationException, organizationFiscalCode);
       }
       throw new AppException(AppError.DEBT_POSITION_UPDATE_FAILED, organizationFiscalCode);
+    } catch (OptimisticLockingFailureException e) {
+      throw new AppException(AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE, organizationFiscalCode);
     } catch (Exception e) {
       // Log the entire exception for debugging purposes.
       log.error("Error during debt position update process", e);

--- a/src/test/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDServiceTest.java
+++ b/src/test/java/it/gov/pagopa/debtposition/service/pd/crud/PaymentPositionCRUDServiceTest.java
@@ -26,6 +26,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -314,6 +315,114 @@ class PaymentPositionCRUDServiceTest {
     assertEquals(AppError.DEBT_POSITION_PO_METADATA_UNIQUE_VIOLATION.title, exception.getTitle());
   }
 
+  @Test
+  void createDebtPosition_OptimisticLockingFailureException_throwsSpecificAppException() {
+    String organizationFiscalCode = "02406911202";
+
+    when(paymentPositionRepository.saveAndFlush(any()))
+            .thenThrow(optimisticLockingFailureException());
+
+    PaymentPosition paymentPosition = new PaymentPosition();
+
+    AppException exception =
+            assertThrows(
+                    AppException.class,
+                    () ->
+                            paymentsService.create(
+                                    paymentPosition,
+                                    organizationFiscalCode,
+                                    false,
+                                    null));
+
+    assertEquals(
+            AppError.DEBT_POSITION_CONCURRENT_CREATION_FAILURE,
+            exception.getAppError());
+  }
+
+  @Test
+  void createMultiDebtPosition_OptimisticLockingFailureException_throwsSpecificAppException() {
+    String organizationFiscalCode = "02406911202";
+
+    when(paymentPositionRepository.saveAllAndFlush(anyList()))
+            .thenThrow(optimisticLockingFailureException());
+
+    List<PaymentPosition> paymentPositions = List.of(new PaymentPosition());
+
+    AppException exception =
+            assertThrows(
+                    AppException.class,
+                    () ->
+                            paymentsService.createMultipleDebtPositions(
+                                    paymentPositions,
+                                    organizationFiscalCode,
+                                    false,
+                                    null));
+
+    assertEquals(
+            AppError.DEBT_POSITION_CONCURRENT_CREATION_FAILURE,
+            exception.getAppError());
+  }
+
+  @Test
+  void updateDebtPosition_OptimisticLockingFailureException_throwsSpecificAppException() {
+    String organizationFiscalCode = "02406911202";
+
+    PaymentPositionModel paymentPositionModel = new PaymentPositionModel();
+    PaymentPosition ppToUpdate = new PaymentPosition();
+    ppToUpdate.setIupd("IUPD-1");
+    ppToUpdate.setStatus(DebtPositionStatus.DRAFT);
+    ppToUpdate.setPaymentOption(List.of());
+
+    when(paymentPositionRepository.findOne(any(Specification.class)))
+            .thenReturn(Optional.of(ppToUpdate));
+
+    when(paymentPositionRepository.saveAndFlush(any()))
+            .thenThrow(optimisticLockingFailureException());
+    AppException exception =
+            assertThrows(
+                    AppException.class,
+                    () ->
+                            paymentsService.update(
+                                    paymentPositionModel,
+                                    organizationFiscalCode,
+                                    false,
+                                    null));
+
+    assertEquals(
+            AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE,
+            exception.getAppError());
+  }
+
+  @Test
+  void updateMultiDebtPosition_OptimisticLockingFailureException_throwsSpecificAppException() {
+    String organizationFiscalCode = "02406911202";
+
+    List<PaymentPositionModel> paymentPositionModelList = List.of(new PaymentPositionModel());
+    PaymentPosition pp = new PaymentPosition();
+    pp.setIupd("IUPD-1");
+    pp.setStatus(DebtPositionStatus.DRAFT);
+    pp.setPaymentOption(List.of());
+    List< PaymentPosition> managedPositions = List.of(pp);
+    when(paymentPositionRepository.findAll(any(Specification.class), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(managedPositions));
+
+    when(paymentPositionRepository.saveAllAndFlush(anyList()))
+            .thenThrow(optimisticLockingFailureException());
+    AppException exception =
+            assertThrows(
+                    AppException.class,
+                    () ->
+                            paymentsService.updateMultipleDebtPositions(
+                                    paymentPositionModelList,
+                                    organizationFiscalCode,
+                                    false,
+                                    null));
+
+    assertEquals(
+            AppError.DEBT_POSITION_CONCURRENT_UPDATE_FAILURE,
+            exception.getAppError());
+  }
+
   private ConstraintViolationException uniqueViolation(String constraintName) {
     return new ConstraintViolationException(
         "duplicate key value violates unique constraint",
@@ -332,5 +441,9 @@ class PaymentPositionCRUDServiceTest {
 	  return new DataIntegrityViolationException(
 			  "duplicate key value violates unique constraint",
 			  uniqueViolation(constraintName));
+  }
+
+  private OptimisticLockingFailureException optimisticLockingFailureException() {
+    return new OptimisticLockingFailureException("OptimisticLockingFailureException");
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Remapped OptimisticLockingFailureException errors to 409 http error code in place of generic Internal Server Error (500)
<!--- Describe your changes in detail -->

#### Motivation and Context
Concurrent modifications to the same debt position cause unhandled error that is mapped to 500 Internal Server Error, being seen as a service failure that cause availability loss even if those are transient errors that a client retry can resolve (so it have been mapped to 409)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.