### PR TITLE
feat: configure autovacuum settings for specific tables

### DIFF
--- a/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
+++ b/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
@@ -1,0 +1,26 @@
+/*
+ * We apply autovacuum scale factors (1%) strictly at the table level
+ * rather than globally in postgresql.conf.
+ *
+ * Rationale: A global 0.01 setting would trigger constant, unnecessary vacuum cycles
+ * on smaller, frequently updated tables. This wastes CPU/IO resources and leads to
+ * "Autovacuum worker starvation", where all available background workers are busy
+ * cleaning tiny tables, leaving massive tables unattended and prone to severe bloat.
+ * Targeting only these specific large tables ensures timely maintenance without
+ * degrading overall database performance.
+ */
+
+ALTER TABLE apd.payment_position SET (
+    autovacuum_vacuum_scale_factor = 0.01,
+    autovacuum_analyze_scale_factor = 0.01
+);
+
+ALTER TABLE apd.payment_option SET (
+    autovacuum_vacuum_scale_factor = 0.01,
+    autovacuum_analyze_scale_factor = 0.01
+);
+
+ALTER TABLE apd.transfer SET (
+    autovacuum_vacuum_scale_factor = 0.01,
+    autovacuum_analyze_scale_factor = 0.01
+);

--- a/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
+++ b/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
@@ -11,16 +11,16 @@
  */
 
 ALTER TABLE apd.payment_position SET (
-    autovacuum_vacuum_scale_factor = 0.01,
-    autovacuum_analyze_scale_factor = 0.01
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.02
 );
 
 ALTER TABLE apd.payment_option SET (
-    autovacuum_vacuum_scale_factor = 0.01,
-    autovacuum_analyze_scale_factor = 0.01
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.02
 );
 
 ALTER TABLE apd.transfer SET (
-    autovacuum_vacuum_scale_factor = 0.01,
-    autovacuum_analyze_scale_factor = 0.01
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.02
 );

--- a/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
+++ b/src/main/resources/db/migration/apd/V063__AUTOVACUUM_CONFIG.sql
@@ -1,13 +1,6 @@
 /*
- * We apply autovacuum scale factors (1%) strictly at the table level
+ * We apply autovacuum scale factors (2%) strictly at the table level
  * rather than globally in postgresql.conf.
- *
- * Rationale: A global 0.01 setting would trigger constant, unnecessary vacuum cycles
- * on smaller, frequently updated tables. This wastes CPU/IO resources and leads to
- * "Autovacuum worker starvation", where all available background workers are busy
- * cleaning tiny tables, leaving massive tables unattended and prone to severe bloat.
- * Targeting only these specific large tables ensures timely maintenance without
- * degrading overall database performance.
  */
 
 ALTER TABLE apd.payment_position SET (

--- a/src/main/resources/db/migration/apd/V064__DROP_UNUSED_IDX.sql
+++ b/src/main/resources/db/migration/apd/V064__DROP_UNUSED_IDX.sql
@@ -1,0 +1,2 @@
+-- flyway:executeInTransaction=false
+DROP INDEX CONCURRENTLY IF EXISTS apd.idx_status_validity_date;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

This pull request focuses on improving PostgreSQL database maintenance and performance by fine-tuning autovacuum settings for large tables and cleaning up unused indexes. The most important changes are grouped below:

**Database Maintenance and Performance Improvements:**

* Applied table-specific autovacuum settings (`autovacuum_vacuum_scale_factor` and `autovacuum_analyze_scale_factor` set to 0.01) for the `apd.payment_position`, `apd.payment_option`, and `apd.transfer` tables to ensure efficient vacuuming of large tables without impacting smaller tables or overall database performance.

**Database Cleanup:**

* Dropped the unused index `apd.idx_status_validity_date` using a concurrent operation to avoid locking the table during the process.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.